### PR TITLE
Shell script gitattributes for shell script line endings for Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,5 +1,4 @@
-
-#!/bin/bash
+#!/usr/bin/env bash
 
 sleep 45 && \
 sequelize --options-path ./.sequelize-game_changer --env game_changer db:migrate --url "postgresql://postgres:password@postgres/game_changer" && \

--- a/postgres/init/init.sh
+++ b/postgres/init/init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL


### PR DESCRIPTION
This is a quality of life change for Windows users to automatically checkout .sh files with \n line endings and fixed some shebangs. Windows devs can change their global git properties or manually fix the files on checkout but this should be easier. 