### PR TITLE
Fixed bug with expanded terms text matching

### DIFF
--- a/frontend/src/components/modules/policy/policySearchMatrixHandler.js
+++ b/frontend/src/components/modules/policy/policySearchMatrixHandler.js
@@ -643,7 +643,7 @@ const PolicySearchMatrixHandler = {
 				</div>
 
 				{expansionTerms.length>0 && <div style={{width: '100%', marginBottom: 10}}>
-					<GCAccordion expanded={false} header={'ADD SEARCH TERMS'} headerBackground={'rgb(238,241,242)'} headerTextColor={'black'} headerTextWeight={'normal'}>
+					<GCAccordion expanded={false} header={'RELATED TERMS'} headerBackground={'rgb(238,241,242)'} headerTextColor={'black'} headerTextWeight={'normal'}>
 						{ renderExpansionTerms(expansionTerms, handleAddSearchTerm, classes) }
 					</GCAccordion>
 				</div>}

--- a/frontend/src/components/searchMetrics/GCSearchMatrix.js
+++ b/frontend/src/components/searchMetrics/GCSearchMatrix.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import styled from "styled-components";
 import { trackEvent } from '../telemetry/Matomo';
 import {makeStyles} from '@material-ui/core/styles';
-import {getTrackingNameForFactory} from '../../gamechangerUtils';
+import {getTrackingNameForFactory, exactMatch} from '../../gamechangerUtils';
 import {setState} from "../../sharedFunctions";
 import _ from "lodash";
 import SearchMatrixFactory from "../factories/searchMatrixFactory";
@@ -306,7 +306,7 @@ export default function SearchMatrix(props) {
 			}
 		}
 		let topFiveArr = Array.from(topFive)
-		topFiveArr = topFiveArr.map(term => {return {...term, checked:state.searchText.includes(term.phrase)}})
+		topFiveArr = topFiveArr.map(term => {return {...term, checked:exactMatch(state.searchText, term.phrase)}})
 		setExpansionTerms(topFiveArr);
 
 	}, [state, comparableExpansion]);
@@ -317,11 +317,11 @@ export default function SearchMatrix(props) {
 		}
 		let newSearchText = state.searchText.trim()
 		expansionTerms.forEach(({phrase, source, checked}) => {
-			if(checked && !newSearchText.includes(phrase)) {
+			if(checked && !exactMatch(newSearchText, phrase)) {
 				trackEvent(getTrackingNameForFactory(state.cloneData.clone_name), 'QueryExpansion', 'SearchTermAdded', `${phrase}_${source}`);
 				newSearchText = newSearchText.trim() ? `${newSearchText} OR ${phrase}` : phrase;
 			} 
-			else if(!checked && newSearchText.includes(` OR ${phrase}`)) {
+			else if(!checked && exactMatch(newSearchText,`${phrase}`)) {
 				newSearchText = newSearchText.replace(` OR ${phrase}`, "").trim()
 			}
 

--- a/frontend/src/gamechangerUtils.js
+++ b/frontend/src/gamechangerUtils.js
@@ -785,7 +785,7 @@ export const exactMatch = (phrase, word) => {
 	const wordList = phrase.trim().split(' ')
 	let exists = false
 	wordList.forEach(w => {
-		if(w===word){
+		if(w.toLowerCase()===word.toLowerCase()){
 			exists=true
 		}
 	});

--- a/frontend/src/gamechangerUtils.js
+++ b/frontend/src/gamechangerUtils.js
@@ -780,3 +780,14 @@ export const encode = (filename) => {
         match => encodings[match]
     );
 }
+
+export const exactMatch = (phrase, word) => {
+	const wordList = phrase.trim().split(' ')
+	let exists = false
+	wordList.forEach(w => {
+		if(w===word){
+			exists=true
+		}
+	});
+	return exists;
+}


### PR DESCRIPTION
The expanded terms are checked if the searchText contains the term but it wasn't splitting on spaces so you would get the case where: searchText='none' and expandedTerm='no' would be checked. 