### PR TITLE
Task/uot 103021 - Adding source type to QA results

### DIFF
--- a/backend/node_app/modules/policy/policySearchHandler.js
+++ b/backend/node_app/modules/policy/policySearchHandler.js
@@ -406,7 +406,7 @@ class PolicySearchHandler extends SearchHandler {
 								return i['text'] !== '';
 							});
 						}
-						let contextIds = shortenedResults.answers.map(item => 'Source: ' + context[item.context].filename.toUpperCase() + ' (' + context[item.context].resultType + ')');
+						let contextIds = shortenedResults.answers.map(item => 'Source: ' + context[item.context].filename.toUpperCase() + ' (' + context[item.context].resultType.toUpperCase() + ')');
 						let cleanedResults = shortenedResults.answers.map(item => item.text);
 						searchResults.qaResults.answers = cleanedResults;
 						searchResults.qaResults.filenames = contextIds;

--- a/backend/node_app/modules/policy/policySearchHandler.js
+++ b/backend/node_app/modules/policy/policySearchHandler.js
@@ -406,7 +406,7 @@ class PolicySearchHandler extends SearchHandler {
 								return i['text'] !== '';
 							});
 						}
-						let contextIds = shortenedResults.answers.map(item => ' (Source: ' + context[item.context].filename.toUpperCase() + ')');
+						let contextIds = shortenedResults.answers.map(item => 'Source: ' + context[item.context].filename.toUpperCase() + ' (' + context[item.context].resultType + ')');
 						let cleanedResults = shortenedResults.answers.map(item => item.text);
 						searchResults.qaResults.answers = cleanedResults;
 						searchResults.qaResults.filenames = contextIds;


### PR DESCRIPTION
Small change to add the context type (topic, entity, document) the answers for QA. Examples attached.
<img width="1012" alt="Screen Shot 2021-06-14 at 9 27 39 AM" src="https://user-images.githubusercontent.com/41591167/121900357-562f6d00-ccf3-11eb-9fec-781d1624bfa9.png">
<img width="1007" alt="Screen Shot 2021-06-14 at 9 27 18 AM" src="https://user-images.githubusercontent.com/41591167/121900372-5a5b8a80-ccf3-11eb-872a-8241e59e9416.png">
<img width="1002" alt="Screen Shot 2021-06-14 at 9 27 02 AM" src="https://user-images.githubusercontent.com/41591167/121900390-60516b80-ccf3-11eb-9b88-20147516af7e.png">


