### PR TITLE
Uot 101769

### DIFF
--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -311,7 +311,8 @@ class SearchUtility {
 				'crawler_used_s',
 				'download_url_s',
 				'source_page_url_s',
-				'source_fqdn_s'
+				'source_fqdn_s',
+                'display_type_s'
 				], 
 			extStoredFields = [], 
 			extSearchFields = [], 

--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -312,8 +312,8 @@ class SearchUtility {
 				'download_url_s',
 				'source_page_url_s',
 				'source_fqdn_s',
-                'display_source_s'
-				], 
+                                'display_source_s'
+			], 
 			extStoredFields = [], 
 			extSearchFields = [], 
 			includeRevoked = false,

--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -312,7 +312,7 @@ class SearchUtility {
 				'download_url_s',
 				'source_page_url_s',
 				'source_fqdn_s',
-                'display_type_s'
+                'display_source_s'
 				], 
 			extStoredFields = [], 
 			extSearchFields = [], 

--- a/frontend/src/components/dataTracker/GCDataStatusTracker.js
+++ b/frontend/src/components/dataTracker/GCDataStatusTracker.js
@@ -16,7 +16,6 @@ import GameChangerAPI from '../api/gameChanger-service-api';
 import {MemoizedNodeCluster2D}  from "../graph/GraphNodeCluster2D";
 import {getTrackingNameForFactory} from "../../gamechangerUtils";
 import {trackEvent} from "../telemetry/Matomo";
-import {crawlerMappingFunc} from "../../gamechangerUtils";
 
 const TableRow = styled.div`
 	text-align: left;
@@ -425,7 +424,7 @@ const GCDataStatusTracker = (props) => {
 							style={{ color: '#386F94' }}
 						>
 						<div>
-							<p>{crawlerMappingFunc(JSON.parse(props.original.json_metadata).crawler_used)}</p>
+							<p>{JSON.parse(props.original.json_metadata).display_source_s}</p>
 						</div>
 						</Link>
 					</TableRow>
@@ -500,7 +499,7 @@ const GCDataStatusTracker = (props) => {
 				width: 350,
 				Cell: row => (
 					<TableRow>
-						{crawlerMappingFunc(row.value)}
+						{JSON.parse(props.original.json_metadata).display_source_s}
 					</TableRow>
 				),
 			},
@@ -584,7 +583,7 @@ const GCDataStatusTracker = (props) => {
 				width: 350,
 				Cell: row => (
 					<TableRow>
-						{crawlerMappingFunc(row.value)}
+						{JSON.parse(props.original.json_metadata).display_source_s}
 					</TableRow>
 				),
 			},

--- a/frontend/src/components/modules/policy/policyCardHandler.js
+++ b/frontend/src/components/modules/policy/policyCardHandler.js
@@ -479,7 +479,6 @@ const getCardHeaderHandler = ({item, state, idx, checkboxComponent, favoriteComp
 	
 	const displayOrg = item['display_org_s'] ? item['display_org_s'] : 'Uncategorized';
 	const displayType = item['display_doc_type_s'] ? item['display_doc_type_s'] : 'Document';
-	console.log(item);
 	let publicationDate;
 	if(item.publication_date_dt !== undefined && item.publication_date_dt !== ''){
 		const currentDate = new Date(item.publication_date_dt);

--- a/frontend/src/components/modules/policy/policyCardHandler.js
+++ b/frontend/src/components/modules/policy/policyCardHandler.js
@@ -1,6 +1,5 @@
 import React from "react";
 import {trackEvent} from "../../telemetry/Matomo";
-import {crawlerMappingFunc} from "../../../gamechangerUtils";
 import {
 	CARD_FONT_SIZE,
 	getDocTypeStyles,

--- a/frontend/src/components/modules/policy/policyCardHandler.js
+++ b/frontend/src/components/modules/policy/policyCardHandler.js
@@ -480,7 +480,7 @@ const getCardHeaderHandler = ({item, state, idx, checkboxComponent, favoriteComp
 	
 	const displayOrg = item['display_org_s'] ? item['display_org_s'] : 'Uncategorized';
 	const displayType = item['display_doc_type_s'] ? item['display_doc_type_s'] : 'Document';
-	
+	console.log(item);
 	let publicationDate;
 	if(item.publication_date_dt !== undefined && item.publication_date_dt !== ''){
 		const currentDate = new Date(item.publication_date_dt);
@@ -870,15 +870,15 @@ const PolicyCardHandler = {
 			}
 
 			let source_item;
-			if(item.source_fqdn_s !== undefined && item.source_fqdn_s !== '' && item.crawler_used_s !== undefined && item.crawler_used_s !== ''){
+			if(item.source_fqdn_s !== undefined && item.source_fqdn_s !== '' && item.crawler_used_s!== undefined && item.crawler_used_s!== ''){
 				let source_name;
 				if (item.source_fqdn_s.startsWith("https://")){
 					source_name = item.source
 				} else {
 					source_name = `https://${item.source_fqdn_s}`
 				}
-				source_item = (<a href= {source_name} target="_blank" rel="noopener noreferrer">{crawlerMappingFunc(item.crawler_used_s)}</a>)
-			} else {
+				source_item = (<a href= {source_name} target="_blank" rel="noopener noreferrer">{item.display_source_s}</a>)
+            } else {
 				source_item = 'unknown';
 			}
 

--- a/frontend/src/gamechangerUtils.js
+++ b/frontend/src/gamechangerUtils.js
@@ -268,40 +268,7 @@ export function numberWithCommas(x) {
 	if (!x) return x;
 	return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
-// no longer need crawlerMapping as we store display_source_s
-/*
-const crawlerMapping = {
-	"dod_issuances":"WHS DoD Directives Division",
-	"army_pubs":"Army Publishing Directorate", 
-	"jcs_pubs":"Joint Chiefs of Staff Library",
-	"jcs_manual_uploads":"Joint Chiefs of Staff",
-	"dod_manual_uploads":"Dept. of Defense",
-	"army_manual_uploads":"US Army",
-	"ic_policies":"Director of National Intelligence",
-	"us_code":"Office of the Law Revision Counsel",
-	"ex_orders":"Federal Register",
-	"opm_pubs":"OMB Publication",
-	"air_force_pubs":"Dept. of the Air Force E-Publishing",
-	"marine_pubs":"Marine Corps Publications Electronic Library",
-	"secnav_pubs":"Dept. of the Navy Issuances",
-	"navy_reserves":"U.S. Navy Reserve Publications",
-	"navy_med_pubs":"Navy Medicine Directives",
-	"Bupers_Crawler":"Bureau of Naval Personnel Instructions",
-	"milpersman_crawler":"Navy Personnel Command Instructions",
-	"nato_stanag":"NATO Publications",
-	"fmr_pubs":"DoD Financial Management Regulation",
-	"legislation_pubs":"Congressional Legislation",
-	"Army_Reserve":"U.S. Army Reserve Publications",
-	"Memo":"OSD Executive Executive Secretary",
-	"dha_pubs":"Military Health System",
-	"jumbo_FAR":"Federal Acquisition Regulation",
-	"jumbo_DFAR":"Defense Federal Acquisition Regulation"
-} 
 
-export const crawlerMappingFunc = (item) => {
-	return crawlerMapping[item]? crawlerMapping[item] : item
-}
-*/
 export const orgColorMap = {
 	'Dept. of Defense': '#636363', // gray
 	'Joint Chiefs of Staff': '#330066', // purple

--- a/frontend/src/gamechangerUtils.js
+++ b/frontend/src/gamechangerUtils.js
@@ -268,7 +268,8 @@ export function numberWithCommas(x) {
 	if (!x) return x;
 	return x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
 }
-
+// no longer need crawlerMapping as we store display_source_s
+/*
 const crawlerMapping = {
 	"dod_issuances":"WHS DoD Directives Division",
 	"army_pubs":"Army Publishing Directorate", 
@@ -300,7 +301,7 @@ const crawlerMapping = {
 export const crawlerMappingFunc = (item) => {
 	return crawlerMapping[item]? crawlerMapping[item] : item
 }
-
+*/
 export const orgColorMap = {
 	'Dept. of Defense': '#636363', // gray
 	'Joint Chiefs of Staff': '#330066', // purple


### PR DESCRIPTION
removed crawlerMapping function from gamechangerUtils. This function was being used to populate the source field on the back of GC card by passing in the crawler used and outputting the associated display source field. See pic attached. 

Necessary changes:
* add `display_source_s` field to stored fields when making elastic search query
* no longer require crawlerMapping function to populate the back of the card
* updated the data status tracker table to no longer depend on crawlerMapping function and instead be able to pull the display_source_s field directly 
* removed crawlerMapping function from utils 
<img width="368" alt="Screen Shot 2021-06-15 at 1 02 41 PM" src="https://user-images.githubusercontent.com/36052099/122108888-fb247580-cdd9-11eb-8bb2-8b7661723112.png">
