### PR TITLE
Bugfix/uot 104260 - making QA work when entities index is not updated

### DIFF
--- a/backend/node_app/modules/policy/policySearchHandler.js
+++ b/backend/node_app/modules/policy/policySearchHandler.js
@@ -378,6 +378,7 @@ class PolicySearchHandler extends SearchHandler {
 		searchResults.qaResults = {question: '', answers: [], filenames: [], docIds: []};
 		searchResults.qaContext = {params: {}, context: []};
 		const permissions = req.permissions ? req.permissions : [];
+		let entityQAResults = {};
 		let qaParams = {maxLength: 3000, maxDocContext: 3, maxParaContext: 3, minLength: 350, scoreThreshold: 100, entitylimit: 4};
 		searchResults.qaContext.params = qaParams;
 		if (permissions) {
@@ -398,9 +399,13 @@ class PolicySearchHandler extends SearchHandler {
 					let qaEntityQuery = this.searchUtility.phraseQAEntityQuery(qaSearchTextList, qaParams.entityLimit, userId);
 					let esClientName = 'gamechanger';
 					let esIndex = 'gamechanger';
-					let entitiesIndex = 'entities-new';
+					try {
+						let entitiesIndex = 'entities';
+						entityQAResults = await this.dataLibrary.queryElasticSearch(esClientName, entitiesIndex, qaEntityQuery, userId);
+					} catch (e) {
+						this.logger.error(e.message, 'KQ68CHSU');
+					}
 					let contextResults = await this.dataLibrary.queryElasticSearch(esClientName, esIndex, qaQuery, userId);
-					let entityQAResults = await this.dataLibrary.queryElasticSearch(esClientName, entitiesIndex, qaEntityQuery, userId);
 					let context = await this.searchUtility.getQAContext(contextResults, entityQAResults, searchResults.sentResults, userId, qaParams);
 					searchResults.qaContext.context = context;
 					if (testing === true) {

--- a/backend/node_app/modules/policy/policySearchHandler.js
+++ b/backend/node_app/modules/policy/policySearchHandler.js
@@ -399,8 +399,8 @@ class PolicySearchHandler extends SearchHandler {
 					let qaEntityQuery = this.searchUtility.phraseQAEntityQuery(qaSearchTextList, qaParams.entityLimit, userId);
 					let esClientName = 'gamechanger';
 					let esIndex = 'gamechanger';
+					let entitiesIndex = 'entities';
 					try {
-						let entitiesIndex = 'entities';
 						entityQAResults = await this.dataLibrary.queryElasticSearch(esClientName, entitiesIndex, qaEntityQuery, userId);
 					} catch (e) {
 						this.logger.error(e.message, 'KQ68CHSU');

--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -5,7 +5,6 @@ const { MLApiClient } = require('../lib/mlApiClient');
 const { DataLibrary} = require('../lib/dataLibrary');
 const neo4jLib = require('neo4j-driver');
 const fs = require('fs');
-const { PassThrough } = require('stream');
 
 const TRANSFORM_ERRORED = 'TRANSFORM_ERRORED';
 

--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -5,6 +5,7 @@ const { MLApiClient } = require('../lib/mlApiClient');
 const { DataLibrary} = require('../lib/dataLibrary');
 const neo4jLib = require('neo4j-driver');
 const fs = require('fs');
+const { PassThrough } = require('stream');
 
 const TRANSFORM_ERRORED = 'TRANSFORM_ERRORED';
 
@@ -1176,7 +1177,7 @@ class SearchUtility {
 						context.push(contextPara); // only keep actual paragraphs not empty strings/titles/headers
 					}
 				}
-			}
+			};
 			if (sentResults) {
 				for (var i = 0; i < sentResults.length; i++) {
 					try {
@@ -1209,8 +1210,8 @@ class SearchUtility {
 						LOGGER.error(e.message, 'LOQXIPY', userId);
 					}
 				}
-			}
-			if (entityQAResults.body.hits.total.value > 0) {
+			};
+			if (entityQAResults.body) {
 				try{
 					let docId;
 					let resultType;


### PR DESCRIPTION
- Changed the name of the entities index to `entities` (which doesn't have the correct mapping in dev/prod to work with the latest QA updates)
- Added try/catch block to step of retrieving entities for context so it doesn't break all of QA when the index is not updated