### PR TITLE
task/uot-105092 fix combo docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+**/node_modules/

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,8 +1,7 @@
 FROM node:14
-COPY .npmrc .npmrc
-RUN npm install -g nodemon
-RUN npm install -g sequelize-cli
-RUN npm install -g jest
+RUN npm install -g nodemon \
+    && npm install -g sequelize-cli \
+    && npm install -g jest
 COPY . /usr/src/app
 WORKDIR /usr/src/app/frontend
 RUN npm install
@@ -10,5 +9,4 @@ RUN npm run build
 RUN mv build ../backend/
 WORKDIR /usr/src/app/backend
 RUN npm install
-RUN rm -f .npmrc
 CMD ./startProd.sh

--- a/docker-compose.combo.yml
+++ b/docker-compose.combo.yml
@@ -19,30 +19,6 @@ services:
             - "6379:6379"
         networks:
             - app-net
-    mysql:
-        image: mysql
-        environment:
-            - MYSQL_ROOT_PASSWORD=password
-        command: --default-authentication-plugin=mysql_native_password
-        volumes:
-            - mysql:/var/lib/mysql
-        networks:
-            - app-net
-    matomo:
-        image: matomo
-        environment: 
-            - MATOMO_DATABASE_HOST=mysql
-            - MATOMO_DATABASE_USERNAME=root
-            - MATOMO_DATABASE_PASSWORD=password
-            - MATOMO_DATABASE_DBNAME=matomo
-        depends_on: 
-            - mysql
-        ports:
-            - 80:80
-        volumes:
-            - matomo:/var/www/html
-        networks:
-            - app-net
     gamechanger-web:
         container_name: gamechanger-web
         build:

--- a/docker-compose.combo.yml
+++ b/docker-compose.combo.yml
@@ -1,20 +1,48 @@
 version: '3'
 services:
-    postgres:
-        container_name: postgres
+    web-postgres:
+        container_name: web-postgres
         build:
             context: ./postgres/
         ports:
-            - "5432:5432"
+            - "5433:5432"
         volumes:
-            - ./postgres/data:/var/lib/postgresql/data
+            - postgres:/var/lib/postgresql/data
         environment:
             - POSTGRES_HOST_AUTH_METHOD=trust
+        networks:
+            - app-net
     redis:
         container_name: redis
         image: redis
         ports: 
-           - "6379:6379"
+            - "6379:6379"
+        networks:
+            - app-net
+    mysql:
+        image: mysql
+        environment:
+            - MYSQL_ROOT_PASSWORD=password
+        command: --default-authentication-plugin=mysql_native_password
+        volumes:
+            - mysql:/var/lib/mysql
+        networks:
+            - app-net
+    matomo:
+        image: matomo
+        environment: 
+            - MATOMO_DATABASE_HOST=mysql
+            - MATOMO_DATABASE_USERNAME=root
+            - MATOMO_DATABASE_PASSWORD=password
+            - MATOMO_DATABASE_DBNAME=matomo
+        depends_on: 
+            - mysql
+        ports:
+            - 80:80
+        volumes:
+            - matomo:/var/www/html
+        networks:
+            - app-net
     gamechanger-web:
         container_name: gamechanger-web
         build:
@@ -23,10 +51,10 @@ services:
             args:
                 MIGRATION_HOST: postgres
         environment:
-            - POSTGRES_HOST_GAME_CHANGER=postgres
+            - POSTGRES_HOST_GAME_CHANGER=web-postgres
             - POSTGRES_USER_GAME_CHANGER=postgres
             - POSTGRES_PASSWORD_GAME_CHANGER=password
-            - POSTGRES_HOST_GC_ORCHESTRATION=postgres
+            - POSTGRES_HOST_GC_ORCHESTRATION=web-postgres
             - POSTGRES_USER_GC_ORCHESTRATION=postgres
             - POSTGRES_PASSWORD_GC_ORCHESTRATION=password
         ports:
@@ -35,6 +63,17 @@ services:
         volumes:
             - ./:/usr/app/
             # - /usr/app/backend/node_modules
+        networks:
+            - app-net
         depends_on:
-            - postgres
+            - web-postgres
             - redis
+
+networks:
+    app-net:
+        name: "${COMPOSE_PROJECT_NAME:-gc-dev}-network"
+
+volumes:
+    postgres:
+    mysql:
+    matomo:

--- a/docker-compose.matomo.yml
+++ b/docker-compose.matomo.yml
@@ -1,0 +1,36 @@
+version: '3'
+services:
+    mysql:
+        image: mysql:8.0
+        container_name: mysql
+        environment:
+            - MYSQL_ROOT_PASSWORD=password
+        command: --default-authentication-plugin=mysql_native_password
+        volumes:
+            - mysql:/var/lib/mysql
+        networks:
+            - app-net
+    matomo:
+        image: matomo:4.3
+        container_name: matomo
+        environment: 
+            - MATOMO_DATABASE_HOST=mysql
+            - MATOMO_DATABASE_USERNAME=root
+            - MATOMO_DATABASE_PASSWORD=password
+            - MATOMO_DATABASE_DBNAME=matomo
+        depends_on: 
+            - mysql
+        ports:
+            - 80:80
+        volumes:
+            - matomo:/var/www/html
+        networks:
+            - app-net
+
+networks:
+  app-net:
+    name: "${COMPOSE_PROJECT_NAME:-gc-dev}-network"
+
+volumes:
+    mysql:
+    matomo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,30 +19,6 @@ services:
            - "6379:6379"
         networks:
             - app-net
-    mysql:
-        image: mysql
-        environment:
-            - MYSQL_ROOT_PASSWORD=password
-        command: --default-authentication-plugin=mysql_native_password
-        volumes:
-            - mysql:/var/lib/mysql
-        networks:
-            - app-net
-    matomo:
-        image: matomo
-        environment: 
-            - MATOMO_DATABASE_HOST=mysql
-            - MATOMO_DATABASE_USERNAME=root
-            - MATOMO_DATABASE_PASSWORD=password
-            - MATOMO_DATABASE_DBNAME=matomo
-        depends_on: 
-            - mysql
-        ports:
-            - 80:80
-        volumes:
-            - matomo:/var/www/html
-        networks:
-            - app-net
     gamechanger-web-node:
         container_name: gamechanger-web-node
         build:

--- a/resetComboDocker.sh
+++ b/resetComboDocker.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
 VOLUMES=0
+COMPOSE_FILES_ARGS="-f docker-compose.combo.yml"
 while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
     --volumes)
       VOLUMES=1
+      shift # past argument
+      ;;
+    --matomo)
+      COMPOSE_FILES_ARGS="$COMPOSE_FILES_ARGS -f docker-compose.matomo.yml"
       shift # past argument
       ;;
     *)    # unknown option
@@ -19,5 +24,5 @@ docker system prune -f
 if (($VOLUMES)); then
   docker system prune --volumes -f
 fi
-docker-compose -f docker-compose.combo.yml build
-docker-compose -f docker-compose.combo.yml up
+docker-compose $COMPOSE_FILES_ARGS build
+docker-compose $COMPOSE_FILES_ARGS up

--- a/resetDocker.sh
+++ b/resetDocker.sh
@@ -1,11 +1,16 @@
 #!/usr/bin/env bash
 
 VOLUMES=0
+COMPOSE_FILES_ARGS="-f docker-compose.yml"
 while [[ $# -gt 0 ]]; do
   key="$1"
   case $key in
     --volumes)
       VOLUMES=1
+      shift # past argument
+      ;;
+    --matomo)
+      COMPOSE_FILES_ARGS="$COMPOSE_FILES_ARGS -f docker-compose.matomo.yml"
       shift # past argument
       ;;
     *)    # unknown option
@@ -19,5 +24,5 @@ docker system prune -f
 if (($VOLUMES)); then
   docker system prune --volumes -f
 fi
-docker-compose build
-docker-compose up
+docker-compose $COMPOSE_FILES_ARGS build
+docker-compose $COMPOSE_FILES_ARGS up


### PR DESCRIPTION
The previous merge broke the combo docker compose. This fixes this and moves the matomo containers to an optional compose file while we figure out how to automate the configuration (development can continue to use the external instance as it has been doing to date).