### PR TITLE
Bugfix/uot 110508 undefined topic page

### DIFF
--- a/frontend/src/components/modules/policy/policyCardHandler.js
+++ b/frontend/src/components/modules/policy/policyCardHandler.js
@@ -1462,7 +1462,7 @@ const PolicyCardHandler = {
 		getFooter: (props) => {
 
 			const {
-				name,
+				item,
 				cloneName,
 				graphView,
 				closeGraphCard,
@@ -1475,9 +1475,9 @@ const PolicyCardHandler = {
 					<>
 						<CardButton target={'_blank'} style={{...styles.footerButtonBack, CARD_FONT_SIZE}} href={'#'}
 							onClick={(e) => {
-								trackEvent(getTrackingNameForFactory(cloneName), 'TopicCardOnClick', 'Open', `${name}DetailsPage`);
+								trackEvent(getTrackingNameForFactory(cloneName), 'TopicCardOnClick', 'Open', `${item.name}DetailsPage`);
 								e.preventDefault();
-								window.open(`#/gamechanger-details?type=topic&topicName=${name}&cloneName=${cloneName}`);
+								window.open(`#/gamechanger-details?type=topic&topicName=${item.name}&cloneName=${cloneName}`);
 							}}
 						>
 							Open

--- a/frontend/src/components/modules/policy/policyCardHandler.js
+++ b/frontend/src/components/modules/policy/policyCardHandler.js
@@ -1475,9 +1475,9 @@ const PolicyCardHandler = {
 					<>
 						<CardButton target={'_blank'} style={{...styles.footerButtonBack, CARD_FONT_SIZE}} href={'#'}
 							onClick={(e) => {
-								trackEvent(getTrackingNameForFactory(cloneName), 'TopicCardOnClick', 'Open', `${item.name}DetailsPage`);
+								trackEvent(getTrackingNameForFactory(cloneName), 'TopicCardOnClick', 'Open', `${item.name.toLowerCase()}DetailsPage`);
 								e.preventDefault();
-								window.open(`#/gamechanger-details?type=topic&topicName=${item.name}&cloneName=${cloneName}`);
+								window.open(`#/gamechanger-details?type=topic&topicName=${item.name.toLowerCase()}&cloneName=${cloneName}`);
 							}}
 						>
 							Open

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -552,7 +552,6 @@ const GameChangerDetailsPage = (props) => {
 	}
 	
 	const renderTopicContainer = () => {
-		debugger;
 		return (
 			<div>
 				<p  style={{margin: '10px 4%', fontSize: 18}}>Welcome to our new (Beta version) Topic Details page! As you look around, you may note some technical issues below; please bear with us while we continue making improvements here and check back often for a more stable version.</p>


### PR DESCRIPTION
## Description
This fixes the topics from the topic card going to undefined but it is unclear where topics that aren't in neo4j are showing up from. 

## Related Issue/Ticket

[UOT-110508](https://jira.di2e.net/browse/UOT-110508)

## Testing instructions

-Run a search that pulls up a topic card i.e. 'Navy' and click on open.
-Topic details page should open with correct topic instead of undefined in URL.