### PR TITLE
Fix for Organization Details Page

### DIFF
--- a/backend/node_app/modules/policy/policyGraphHandler.js
+++ b/backend/node_app/modules/policy/policyGraphHandler.js
@@ -611,6 +611,13 @@ class PolicyGraphHandler extends GraphHandler {
 					ORDER BY mentions DESC LIMIT 100;`, {entityName: entityName}, isTest, userId
 			);
 
+			if (doc_ids[0].doc_id === null) {
+				return {
+					totalCount: 0,
+					docs: []
+				};
+			}
+
 			const docIds = doc_ids.map(docId => {
 				return docId.doc_id;
 			});

--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -2036,7 +2036,7 @@ class SearchUtility {
 					node.topicScore = recObj.topicScore;
 					addNode(node);
 				} else if (recObj.hasOwnProperty('doc_id')) {
-					docIds.push({doc_id: recObj.doc_id, mentions: recObj.mentions.low});
+					docIds.push({doc_id: recObj.doc_id, mentions: recObj.mentions?.low});
 				} else if (recObj.hasOwnProperty('primary_key')) {
 					graphMetaData.push({
 						label: recObj.label,

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -431,7 +431,7 @@ const GameChangerDetailsPage = (props) => {
 			setDocResultsPage(1);
 			setDocResults(resp.data.docs);
 			setVisibleDocs(resp.data.docs.slice(1, RESULTS_PER_PAGE + 1));
-			if(resp.data.docs.length > 0) {
+			if(resp.data.docs.length > 0 || resp.data.totalCount === 0) {
 				setTimeFound(((t1 - t0) / 1000).toFixed(2));
 				setGettingDocuments(false);
 			}

--- a/frontend/src/graphUtils.js
+++ b/frontend/src/graphUtils.js
@@ -120,8 +120,6 @@ export const draw2DArrows = (link, ctx, globalScale, arrowLength, arrowRelativeP
 
 export const  getNodeColors = (node, alpha, nodeLabelColors = {}) => {
 	
-	console.log(node)
-
 	if (nodeLabelColors[node?.label] && nodeLabelColors[node?.label].color === '') {
 		
 		shuffleArray(NODE_COLORS);


### PR DESCRIPTION
Organizations that do not have any related documents would throw errors on front and back end when hitting the details page.

This PR adds null checking in back end and will return an empty response instead of an error.