### PR TITLE
Fixed the FAQ path

### DIFF
--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -107,7 +107,7 @@ const endpoints = {
 	sendFrontendErrorPOST: '/api/gameChanger/sendFrontendError',
 	getOrgImageOverrideURLs: '/api/gameChanger/getOrgImageOverrideURLs',
 	saveOrgImageOverrideURL: '/api/gameChanger/saveOrgImageOverrideURL',
-	getFAQ: 'api/gamechanger/aboutGC/getFAQ',
+	getFAQ: '/api/gamechanger/aboutGC/getFAQ',
 
 
 	exportHistoryDELETE: function(id){


### PR DESCRIPTION
The path without the '/' at the start messed up the signature that was being created by the webapp to check that the request was coming from the webapp. 