### PR TITLE
Bugfix/pagination concatenation

### DIFF
--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -123,6 +123,7 @@ const PolicySearchHandler = {
         setState(dispatch, {
 			selectedDocuments: new Map(),
 			loading: searchSettings.isFilterUpdate ? false: true,
+            replaceResults: true,
             metricsLoading: false,
 			noResultsMessage: null,
 			autocompleteItems: [],

--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -123,7 +123,6 @@ const PolicySearchHandler = {
         setState(dispatch, {
 			selectedDocuments: new Map(),
 			loading: searchSettings.isFilterUpdate ? false: true,
-            replaceResults: true,
             metricsLoading: false,
 			noResultsMessage: null,
 			autocompleteItems: [],

--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -123,7 +123,7 @@ const PolicySearchHandler = {
         setState(dispatch, {
 			selectedDocuments: new Map(),
 			loading: searchSettings.isFilterUpdate ? false: true,
-            replaceResults: searchSettings.isFilterUpdate ? true: false,
+            replaceResults: true,
             metricsLoading: false,
 			noResultsMessage: null,
 			autocompleteItems: [],


### PR DESCRIPTION
## Description

Fixes bug where clicking a new page in documents pagination add the results to the bottom rather than refreshing with a new page of documents.

## Related Issue/Ticket
UOT-114347

## Testing instructions

Play around with the pagination of a documents result of a search. Make sure "All" catgories are selected to have pagination present.