### PR TITLE
bugfix/UOT-114360 topic details fix

### DIFF
--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -453,7 +453,7 @@ const GameChangerDetailsPage = (props) => {
 	useEffect(() => {
 
 		if (!topic || !cloneData || graph.nodes.length <= 0) return;
-		let searchText = `"${topic.name}"`;
+		let searchText = `${topic.name}`;
 		
 		const docIds = [];
 		


### PR DESCRIPTION
## Description
The quotes in the topic details page were forcing an exact match in elasticsearch this was making some topics not pull any docs.

## Related Issue/Ticket

[https://jira.di2e.net/browse/UOT-114360](UOT-114360)

## Testing instructions

-Search 'army' and flip the first card.
-Click on the 'delegation authority' topic to open the details page
-There should be documents in the second accordion.