### PR TITLE
Fixed overflow issue with export list in side panel

### DIFF
--- a/frontend/src/components/searchBar/GCSelectedDocsDrawer.js
+++ b/frontend/src/components/searchBar/GCSelectedDocsDrawer.js
@@ -22,6 +22,7 @@ const DrawerTable = styled(Table)`
     border: 1px solid ${backgroundGreyDark};
     margin: 0 16px;
     width: 93% !important;
+    table-layout:fixed;
 `;
 
 const DrawerTableRow = styled(TableRow)`
@@ -37,6 +38,7 @@ const ButtonRow = styled.div`
 const DrawerTableCell = styled(TableCell)`
     display: flex !important;
     justify-content: space-between !important;
+    max-width: 100% !important;
 `;
 
 export const SelectedDocsDrawer = (props) => {
@@ -82,7 +84,7 @@ export const SelectedDocsDrawer = (props) => {
                             width: '100%',
                             justifyContent: 'space-between'
                         }}>
-                            <span style={{ fontSize: 16 }}>{value}</span>
+                            <span style={{ fontSize: 16, overflow: 'hidden', textOverflow: 'ellipsis' }}>{value}</span>
                             <i className="fa fa-times-circle fa-fw" style={{ cursor: 'pointer', height: 17 }} onClick={()=>handleRemoveSelection(key)} />
                         </div>
                     </DrawerTableCell>


### PR DESCRIPTION
## Description
A visual bug existed where the filenames of exports listed in the side drawer were cut off about halfway through the row. This fixes that.

## Related Issue/Ticket
UOT-112064

## Testing instructions
-Search anything in Gamechanger. Select a few documents for export. Click the export button in the viewheader. The filenames should display nicely in the side drawer and function normally. The remove "x" buttons should remove single items. 