### PR TITLE
start backend node app in debug mode and expose port in dev container

### DIFF
--- a/backend/start.sh
+++ b/backend/start.sh
@@ -6,4 +6,4 @@ sequelize --options-path ./.sequelize-gc-orchestration --env gc_orchestration db
 psql -U postgres -h web-postgres -d game_changer -f /usr/src/app/node_app/init/create_clones.sql && \
 psql -U postgres -h web-postgres -d game_changer -f /usr/src/app/node_app/init/create_admins.sql && \
 psql -U postgres -h web-postgres -d game_changer -f /usr/src/app/node_app/init/pop_mini_RE.sql && \
-nodemon -x 'node index.js || (sleep 10; touch index.js)'
+nodemon -x 'sleep 1 && node --inspect=0.0.0.0:9229 index.js || (sleep 10; touch index.js)'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
         ports:
             # - "5860:5860"
             - "8990:8990"
+            - "9229:9229"
         volumes:
             - ./backend/:/usr/src/app/
             - /usr/src/app/node_modules


### PR DESCRIPTION
Sometimes it's nice to attach a debugger. This PR simply enables debug mode and exposes the port on the backend dev container. The initial sleep helps mitigate "the port is already in use" errors when nodemon restarts the app.