### PR TITLE
Prevent Favorite in Group Missing from Causing Crash

### DIFF
--- a/frontend/src/components/cards/GCGroupCard.js
+++ b/frontend/src/components/cards/GCGroupCard.js
@@ -89,8 +89,12 @@ const GroupCard = (props) => {
 		const doc = state.userData.favorite_documents.find(doc => {
 			return favId === doc.favorite_id;
 		})
-		favFilenames.set(doc.filename,doc.filename);
-		if(!searchTextlist.includes(doc.search_text)) searchTextlist.push(doc.search_text)
+		if(doc){
+			favFilenames.set(doc.filename,doc.filename);
+			if(!searchTextlist.includes(doc.search_text)) searchTextlist.push(doc.search_text)
+		}else{
+			handleRemoveFavoriteFromGroup(group.id, favId, dispatch);
+		}
 	})
 	const combinedSearchText = searchTextlist.join(' OR ');
 


### PR DESCRIPTION
## Description
If a favorite gets deleted from the database but remains in a group, it would cause a crash on the groups page in the User Dashboard. This fix prevents a crash and removes any anomalies from the DB. 

## Ticket
None

## Testing Instructions
-Manually (using a query) remove a favorite that is in a group from the database. 
(query: delete from favorite_documents where "id" = <whichever fav you're deleting>;)
-Go to the groups page in the User Dashboard to make sure the application doesn't crash. 
-Check the database to make sure the row was removed from the "favorite_documents_groups" table