### PR TITLE
Task/UOT-113361 - Archived Congress Search Filter

### DIFF
--- a/backend/node_app/config/constants.js
+++ b/backend/node_app/config/constants.js
@@ -111,6 +111,7 @@ module.exports = Object.freeze({
 		password: process.env.GAMECHANGER_ELASTICSEARCH_PASSWORD,
 		ca: process.env.GAMECHANGER_ELASTICSEARCH_CA ? process.env.GAMECHANGER_ELASTICSEARCH_CA.replace(/\\n/g, '\n') : '',
 		index: process.env.GAMECHANGER_ELASTICSEARCH_INDEX,
+		legislation_index: 'gamechanger_legislation',
 		history_index: 'search_history',
 		requestTimeout: 60000
 	},

--- a/backend/node_app/modules/policy/policySearchHandler.js
+++ b/backend/node_app/modules/policy/policySearchHandler.js
@@ -134,7 +134,13 @@ class PolicySearchHandler extends SearchHandler {
 			searchFields = {},
 			includeRevoked
 		} = body;
-		const clientObj = {esClientName: 'gamechanger', esIndex: this.constants.GAMECHANGER_ELASTIC_SEARCH_OPTS.index};
+		
+		const clientObj = {
+			esClientName: 'gamechanger',
+			esIndex: body.archivedCongressSelected ?
+				[this.constants.GAMECHANGER_ELASTIC_SEARCH_OPTS.index, this.constants.GAMECHANGER_ELASTIC_SEARCH_OPTS.legislation_index] :
+				this.constants.GAMECHANGER_ELASTIC_SEARCH_OPTS.index
+		};
 
 		try {
 			historyRec.searchText = searchText;

--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -67,6 +67,7 @@ const PolicySearchHandler = {
 			typeFilter,
 			allOrgsSelected,
 			allTypesSelected,
+			archivedCongressSelected,
 			includeRevoked,
 			accessDateFilter,
 			publicationDateFilter,
@@ -239,6 +240,7 @@ const PolicySearchHandler = {
 					publicationDateFilter,
 					publicationDateAllTime,
 					includeRevoked,
+					archivedCongressSelected
 				},
 				limit: 18,
 			});

--- a/frontend/src/components/modules/policy/policySearchMatrixHandler.js
+++ b/frontend/src/components/modules/policy/policySearchMatrixHandler.js
@@ -348,6 +348,18 @@ const handleSelectAllTypes = (state, dispatch) => {
 	}
 };
 
+const handleSelectArchivedCongress = (event, state, dispatch) => {
+	const newSearchSettings = _.cloneDeep(state.searchSettings);
+	newSearchSettings.archivedCongressSelected = event.target.checked;
+	newSearchSettings.isFilterUpdate = true;
+	setState(dispatch, {
+		searchSettings: newSearchSettings,
+		metricsCounted: false,
+		runSearch: true,
+		runGraphSearch: true,
+	});
+};
+
 const handleTypeFilterChangeLocal = (event, state, dispatch, searchbar) => {
 	const newSearchSettings = _.cloneDeep(state.searchSettings);
 	let typeName = event.target.name;
@@ -418,6 +430,31 @@ const renderTypes = (state, dispatch, classes, searchbar = false) => {
 								/>
 							}
 							label="All types"
+							labelPlacement="end"
+							style={styles.titleText}
+						/>
+						<FormControlLabel
+							name="Archived Congress"
+							value="Archived Congress"
+							classes={{ label: classes.titleText }}
+							control={
+								<Checkbox
+									classes={{ root: classes.filterBox }}
+									onClick={(event) => handleSelectArchivedCongress(event, state, dispatch)}
+									icon={
+										<CheckBoxOutlineBlankIcon
+											style={{ visibility: 'hidden' }}
+										/>
+									}
+									checked={state.searchSettings.archivedCongressSelected}
+									checkedIcon={
+										<i style={{ color: '#E9691D' }} className="fa fa-check" />
+									}
+									name="Archived Congress"
+									style={styles.filterBox}
+								/>
+							}
+							label="Archived Congress"
 							labelPlacement="end"
 							style={styles.titleText}
 						/>
@@ -523,6 +560,33 @@ const renderTypes = (state, dispatch, classes, searchbar = false) => {
 								/>
 							}
 							label="All types"
+							labelPlacement="end"
+							style={styles.titleText}
+						/>
+					</FormGroup>
+					<FormGroup row style={{ marginBottom: '10px' }}>
+						<FormControlLabel
+							name="Archived Congress"
+							value="Archived Congress"
+							classes={{ label: classes.titleText }}
+							control={
+								<Checkbox
+									classes={{ root: classes.filterBox }}
+									onClick={(event) => handleSelectArchivedCongress(event, state, dispatch)}
+									icon={
+										<CheckBoxOutlineBlankIcon
+											style={{ visibility: 'hidden' }}
+										/>
+									}
+									checked={state.searchSettings.archivedCongressSelected}
+									checkedIcon={
+										<i style={{ color: '#E9691D' }} className="fa fa-check" />
+									}
+									name="Archived Congress"
+									style={styles.filterBox}
+								/>
+							}
+							label="Archived Congress"
 							labelPlacement="end"
 							style={styles.titleText}
 						/>

--- a/frontend/src/components/searchMetrics/GCSideBar.js
+++ b/frontend/src/components/searchMetrics/GCSideBar.js
@@ -337,7 +337,6 @@ export default function SideBar(props) {
 			}
 		}
 		let topTermsArr = Array.from(topTerms);
-		console.log(topTermsArr);
 		topTermsArr = topTermsArr.map((term) => {
 			return {
 				...term,


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
Adds the Archived Congress search filter to sidebar and advanced search. This filter runs the search on an additional gamechanger_legislation index, returning a superset of the default search.

![image](https://user-images.githubusercontent.com/85301886/138466666-4255ceae-1c22-4d7a-8966-495227bdc787.png)
![image](https://user-images.githubusercontent.com/85301886/138467440-6494fb5f-8a2f-4a63-9678-3eddd6a056a8.png)

## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
https://jira.di2e.net/browse/UOT-113361

## Testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->
By default searches should not be Archived Congress.
Run a search with Archived Congress. It should return more document results of the legislation type.
Type filters should work as expected with Archived Congress checked.
