### PR TITLE
fix for no returned doc results crashing details page

### DIFF
--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -560,14 +560,22 @@ const GameChangerDetailsPage = (props) => {
 			.getDocumentsForTopic(cloneData.clone_name, { docIds, searchText })
 			.then((resp) => {
 				const t1 = new Date().getTime();
-				setDocCount(resp.data.totalCount);
 				setDocResultsPage(1);
-				setDocResults(resp.data.docs);
-				setVisibleDocs(resp.data.docs.slice(0, RESULTS_PER_PAGE + 1));
-				if (resp.data.docs.length > 0) {
-					setTimeFound(((t1 - t0) / 1000).toFixed(2));
+				if(resp.data.docs){
+					setDocCount(resp.data.totalCount);
+					setDocResults(resp.data.docs);
+					setVisibleDocs(resp.data.docs.slice(0, RESULTS_PER_PAGE + 1));
+					if (resp.data.docs.length > 0) {
+						setTimeFound(((t1 - t0) / 1000).toFixed(2));
+						setGettingDocuments(false);
+					}
+				}else{
+					setDocCount(0);
 					setGettingDocuments(false);
 				}
+				
+			}).catch(er => {
+				console.log(er)
 			});
 	}, [topic, graph, cloneData]);
 


### PR DESCRIPTION
## Description
Fixes topic details page crash if no docs are returned

## Testing Instructions
Go to 'bills' topic details page and ensure it does not cause an error