### PR TITLE
hot fix - DST

### DIFF
--- a/frontend/src/components/dataTracker/GCDataStatusTracker.js
+++ b/frontend/src/components/dataTracker/GCDataStatusTracker.js
@@ -413,6 +413,9 @@ const GCDataStatusTracker = (props) => {
 				if (crawler_name === crawler.crawler){
                     return(crawler.data_source_s + ' - ' + crawler.source_title);
 				}
+                else {
+                    return (crawler_name);
+                }
 			}
 		}
 	}


### PR DESCRIPTION
populates source name as crawler if no source title or display title exists 