### PR TITLE
Task/UOT-115292 - Frontend Graph Fixes

### DIFF
--- a/frontend/src/components/graph/GraphNodeCluster2D.js
+++ b/frontend/src/components/graph/GraphNodeCluster2D.js
@@ -1097,7 +1097,11 @@ export default function GraphNodeCluster2D(props) {
 	const handleSimulationStop = onSimulationStop
 		? onSimulationStop
 		: () => {
-			setShouldRunSimulation(false);
+			if (graphData.nodes?.[0].x !== null) {
+				setShouldRunSimulation(false);
+			} else {
+				setShouldRunSimulation(true);
+			}
 
 			if (!graphRendered1stTime) {
 				recenterGraph();

--- a/frontend/src/components/graph/policyGraphView.js
+++ b/frontend/src/components/graph/policyGraphView.js
@@ -1637,7 +1637,7 @@ export default function PolicyGraphView(props) {
 		});
 
 		setShouldRender(true);
-		setReloadGraph(true);
+		setReloadGraph(!reloadGraph);
 		setRunSimulation(!runSimulation);
 	};
 

--- a/frontend/src/components/graph/policyGraphView.js
+++ b/frontend/src/components/graph/policyGraphView.js
@@ -1174,7 +1174,6 @@ export default function PolicyGraphView(props) {
 		const nodeIds = graph.nodes.map((node) => {
 			return node.id;
 		});
-		const parentId = node.id;
 		graphData.nodes.forEach((node) => {
 			if (!nodeIds.includes(node.id)) {
 				node.notInOriginalSearch = true;
@@ -1184,8 +1183,6 @@ export default function PolicyGraphView(props) {
 		});
 		const edgeIds = [];
 		graphData.edges.forEach((edge) => {
-			edge.source = parentId;
-			edge.target = 200000 + edge.target;
 			if (!edgeIds.includes(`${edge.source},${edge.target}`)) {
 				edge.notInOriginalSearch = true;
 				graph.edges.push(edge);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
- Fixes nodes sometimes stacking on top of each other after dismissing a node or resetting the graph
- Fixes reset graph button not working after dismissing an even number of nodes
- Fixes display reference nodes button

## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
https://jira.di2e.net/browse/UOT-115292
https://jira.di2e.net/browse/UOT-118799

## Testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->
1. Open a document graph
2. Dismiss 2 nodes
3. Click reset graph button. Graph should go back to initial state.
4. Click on a document node
5. Click "Display reference nodes for this document". If reference nodes exist they should display.
6. At no point when dismissing/resetting should all the nodes stack on top of each other
