### PR TITLE
Fix favoriting docs on source details page

### DIFF
--- a/frontend/src/components/details/sourceDetailsPage.js
+++ b/frontend/src/components/details/sourceDetailsPage.js
@@ -32,8 +32,7 @@ const getSourceData = async (source, cloneName, page) => {
 	return data;
 };
 
-const SourceDetailsPage = (props) => {
-	const { source, cloneData, initialSourceData } = props;
+const SourceDetailsPage = ({ source, cloneData, initialSourceData, userData, rawSearchResults }) => {
 	const upperSource = source
 		.split(' ')
 		.map((s) => s.charAt(0).toUpperCase() + s.substring(1))
@@ -63,6 +62,8 @@ const SourceDetailsPage = (props) => {
 						componentStepNumbers: {},
 						listView: true,
 						showSideFilters: false,
+						userData,
+						rawSearchResults
 					}}
 					dispatch={() => {}}
 				/>

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -976,6 +976,8 @@ const GameChangerDetailsPage = (props) => {
 					source={source}
 					cloneData={cloneData}
 					initialSourceData={initialSourceData}
+					userData={userData}
+					rawSearchResults={docResults}
 				/>
 			)}
 


### PR DESCRIPTION
Favoriting docs in the "documents from source" accordion on a source details page was crashing. This fix allows adding/removing favorites, changes should be reflected in user dashboard.

Can get to a source details page from homepage