### PR TITLE
Task/UOT-121878 - LTR

### DIFF
--- a/backend/node_app/controllers/appSettingsController.js
+++ b/backend/node_app/controllers/appSettingsController.js
@@ -23,7 +23,8 @@ class AppSettingsController {
 			entitySearch:'entity_search',
 			combinedSearch:'combined_search',
 			topicSearch:'topic_search',
-			jiraFeedback:'jira_feedback'
+			jiraFeedback:'jira_feedback',
+			ltr: 'ltr'
 		}
 		
 		// Binding the key for combined search mode to get and set
@@ -48,6 +49,9 @@ class AppSettingsController {
 		// Binding the key for topic search mode to get and set
 		this.getTopicSearchMode = this.getMode.bind(this, this.keys.topicSearch);
 		this.setTopicSearchMode = this.setMode.bind(this, this.keys.topicSearch);
+
+		this.getLTRMode = this.getMode.bind(this, this.keys.ltr);
+		this.toggleLTRMode = this.toggleMode.bind(this, this.keys.ltr);
 
 		this.logFrontendError = this.logFrontendError.bind(this);
 	}

--- a/backend/node_app/controllers/transformerController.js
+++ b/backend/node_app/controllers/transformerController.js
@@ -27,7 +27,9 @@ class TransformerController {
 			'getProcessStatus': this.mlApi.getProcessStatus,
 			'reloadModels': this.mlApi.reloadModels,
 			'downloadCorpus': this.mlApi.downloadCorpus,
-			'trainModel': this.mlApi.trainModel
+			'trainModel': this.mlApi.trainModel,
+			'initializeLTR': this.mlApi.initializeLTR,
+			'createModelLTR': this.mlApi.createModelLTR
 		}
 
 		// Get methods
@@ -38,6 +40,8 @@ class TransformerController {
 		this.downloadDependencies = this.getData.bind(this, 'downloadDependencies');
 		this.getProcessStatus = this.getData.bind(this, 'getProcessStatus');
 		this.getFilesInCorpus = this.getData.bind(this, 'getFilesInCorpus');
+		this.initializeLTR = this.getData.bind(this, 'initializeLTR');
+		this.createModelLTR = this.getData.bind(this, 'createModelLTR');
 		// Post methods
 		this.setTransformerModel = this.postData.bind(this, 'setTransformerModel');
 		this.reloadModels = this.postData.bind(this, 'reloadModels');

--- a/backend/node_app/lib/mlApiClient.js
+++ b/backend/node_app/lib/mlApiClient.js
@@ -21,6 +21,8 @@ const MLRoutes = {
 	'reloadModels':`${transformerBaseUrl}/reloadModels`,
 	'downloadCorpus':`${transformerBaseUrl}/downloadCorpus`,
 	'trainModel':`${transformerBaseUrl}/trainModel`,
+	'initializeLTR':`${transformerBaseUrl}/LTR/initLTR`,
+	'createModelLTR':`${transformerBaseUrl}/LTR/createModel`,
 	
 }
 /**
@@ -50,6 +52,8 @@ class MLApiClient {
 		this.downloadDependencies = this.getData.bind(this, 'downloadDependencies');
 		this.getFilesInCorpus = this.getData.bind(this, 'getFilesInCorpus');
 		this.getProcessStatus = this.getData.bind(this, 'getProcessStatus');
+		this.initializeLTR = this.getData.bind(this, 'initializeLTR');
+		this.createModelLTR = this.getData.bind(this, 'createModelLTR');
 		// Post methods
 		this.downloadCorpus = this.postData.bind(this, 'downloadCorpus');
 		this.trainModel = this.postData.bind(this, 'trainModel');

--- a/backend/node_app/routes/gameChangerRouter.js
+++ b/backend/node_app/routes/gameChangerRouter.js
@@ -91,6 +91,8 @@ router.get('/admin/getModelsList', transformer.getModelsList);
 router.get('/admin/getCurrentTransformer', transformer.getCurrentTransformer);
 router.get('/admin/getFilesInCorpus', transformer.getFilesInCorpus);
 router.get('/admin/getProcessStatus', transformer.getProcessStatus);
+router.get('/admin/initializeLTR', transformer.initializeLTR);
+router.get('/admin/createModelLTR', transformer.createModelLTR);
 router.post('/admin/downloadCorpus', transformer.downloadCorpus);
 router.post('/admin/trainModel', transformer.trainModel);
 router.post('/admin/reloadModels', transformer.reloadModels);

--- a/backend/node_app/routes/gameChangerRouter.js
+++ b/backend/node_app/routes/gameChangerRouter.js
@@ -178,6 +178,8 @@ router.get('/appSettings/jiraFeedback', appSettings.getJiraFeedbackMode);
 router.post('/appSettings/jiraFeedback', appSettings.toggleJiraFeedbackMode);
 router.get('/appSettings/topicSearch', appSettings.getTopicSearchMode);
 router.post('/appSettings/topicSearch', appSettings.setTopicSearchMode);
+router.get('/appSettings/ltr', appSettings.getLTRMode);
+router.post('/appSettings/ltr', appSettings.toggleLTRMode);
 router.post('/sendFrontendError', appSettings.logFrontendError);
 
 router.post('/sendFeedback/intelligentSearch', feedback.sendIntelligentSearchFeedback);

--- a/backend/node_app/sql/v106.0_insert_admin_settings_ltr.sql
+++ b/backend/node_app/sql/v106.0_insert_admin_settings_ltr.sql
@@ -1,0 +1,2 @@
+INSERT INTO app_settings (key, value)
+VALUES ('ltr', 'false');

--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -368,7 +368,8 @@ class SearchUtility {
 			order = 'desc',
 			includeHighlights = true,
 			docIds = {},
-			selectedDocuments
+			selectedDocuments,
+			ltr = false
 		 }, 
 		 user) {
 
@@ -610,6 +611,20 @@ class SearchUtility {
 					)
 
 			}
+
+			if (ltr) {
+				query.rescore = {
+					query: {
+						rescore_query: {
+							sltr: {
+								params: { keywords: `${parsedQuery}` },
+								model: 'ltr_model'
+							}
+						}
+					}					
+				}
+			}
+
 			return query;
 		} catch (err) {
 			this.logger.error(err, '2OQQD7D', user);

--- a/backend/security_scan/route_check/whitelist.list
+++ b/backend/security_scan/route_check/whitelist.list
@@ -58,6 +58,7 @@
 .* /api/gamechanger/appSettings/userFeedback .*
 .* /api/gamechanger/appSettings/jiraFeedback .*
 .* /api/gamechanger/appSettings/topicSearch .*
+.* /api/gamechanger/appSettings/ltr .*
 .* /api/gamechanger/sendFeedback/intelligentSearch .*
 .* /api/gamechanger/sendFeedback/QA .*
 .* /api/gamechanger/sendFeedback/getFeedbackData .*

--- a/frontend/src/components/admin/GeneralAdminButtons/index.js
+++ b/frontend/src/components/admin/GeneralAdminButtons/index.js
@@ -22,6 +22,7 @@ export default () => {
 	const [userFeedback, setUserFeedback] = useState(true);
 	const [jiraFeedback, setJiraFeedback] = useState(true);
 	const [topicSearch, setTopicSearch] = useState(true);
+	const [ltr, setLTR] = useState(true);
 
 	// EsIndexModal and TrendingBlacklistModal state variables
 	const [showEditEsIndexModal, setShowEditEsIndexModal] = useState(false);
@@ -255,6 +256,28 @@ export default () => {
 		}
 	};
 
+	const toggleLTR = async () => {
+		const title = 'Toggling LTR: ';
+		createAlert(title, 'info', 'Started');
+		try {
+			await gameChangerAPI.toggleLTR().then(() => {
+				createAlert(
+					'Toggling LTR',
+					'success',
+					'updated LTR'
+				);
+				getLTR();
+			});
+		} catch (e) {
+			console.log(e);
+			createAlert(
+				'Toggling LTR',
+				'error',
+				'failed toggling LTR'
+			);
+		}
+	};
+
 	const getCombinedSearch = async () => {
 		try {
 			const { data } = await gameChangerAPI.getCombinedSearchMode();
@@ -303,6 +326,16 @@ export default () => {
 		}
 	};
 
+	const getLTR = async () => {
+		try {
+			const { data } = await gameChangerAPI.getLTRMode();
+			const value = data.value === 'true';
+			setLTR(value);
+		} catch (e) {
+			console.error('Error getting LTR mode', e);
+		}
+	};
+
 	const getTopicSearch = async () => {
 		try {
 			const { data } = await gameChangerAPI.getTopicSearchMode();
@@ -319,6 +352,7 @@ export default () => {
 		getUserFeedback();
 		getTopicSearch();
 		getJiraFeedback();
+		getLTR();
 	}, []);
 
 	return (
@@ -618,6 +652,29 @@ export default () => {
 								<h2 style={styles.featureName}>
 									<span style={styles.featureNameLink}>
 										Toggle Jira User Feedback
+									</span>
+								</h2>
+							</Link>
+						</Paper>
+					</div>
+					<div style={styles.feature}>
+						<Paper
+							style={
+								ltr
+									? styles.paper
+									: { ...styles.paper, backgroundColor: 'rgb(181 52 82)' }
+							}
+							zDepth={2}
+						>
+							<Link
+								to="#"
+								onClick={toggleLTR}
+								style={{ textDecoration: 'none' }}
+							>
+								<i style={styles.image} className="fa fa-id-card-o fa-2x" />
+								<h2 style={styles.featureName}>
+									<span style={styles.featureNameLink}>
+										Toggle LTR
 									</span>
 								</h2>
 							</Link>

--- a/frontend/src/components/admin/MLDashboard/models.js
+++ b/frontend/src/components/admin/MLDashboard/models.js
@@ -724,6 +724,7 @@ export default (props) => {
 							onClick={() => {
 								triggerCreateModelLTR();
 							}}
+							disabled={checkReloading()}
 							style={{ margin: '0 10px 0 0', minWidth: 'unset' }}
 						>
 							Create Model

--- a/frontend/src/components/admin/MLDashboard/models.js
+++ b/frontend/src/components/admin/MLDashboard/models.js
@@ -61,6 +61,9 @@ export default (props) => {
 	const [batchSize, setBatchSize] = useState(32);
 	const [warmupSteps, setWarmupSteps] = useState(100);
 	const [epochs, setEpochs] = useState(3);
+	
+	const [ltrInitializedStatus, setLTRInitializedStatus] = useState(null);
+	const [ltrModelCreatedStatus, setLTRModelCreatedStatus] = useState(null);
 
 	/**
 	 * Load all the initial data on transformers and s3
@@ -239,6 +242,31 @@ export default (props) => {
 			props.updateLogs('Error reloading models: ' + e.toString(), 2);
 		}
 	};
+
+	const triggerInitializeLTR = async () => {
+		try {
+			await gameChangerAPI.initializeLTR().then((data) => {
+				setLTRInitializedStatus(data.status);
+			});
+			props.updateLogs('Initializing LTR', 0);
+			props.getProcesses();
+		} catch (e) {
+			props.updateLogs('Error initializing LTR: ' + e.toString(), 2);
+		}
+	};
+
+	const triggerCreateModelLTR = async () => {
+		try {
+			await gameChangerAPI.createModelLTR().then((data) => {
+				setLTRModelCreatedStatus(data.status);
+			});
+			props.updateLogs('Creating LTR model', 0);
+			props.getProcesses();
+		} catch (e) {
+			props.updateLogs('Error creating LTR model: ' + e.toString(), 2);
+		}
+	};
+
 	/**
 	 * @method checkCorpusDownloading
 	 */
@@ -655,6 +683,64 @@ export default (props) => {
 								style={{ fontSize: 'small', minWidth: '50px', margin: '10px' }}
 							/>
 						</div>
+					</div>
+					<div
+						style={{
+							width: '100%',
+							padding: '20px',
+							marginBottom: '10px',
+							border: '2px solid darkgray',
+							borderRadius: '6px',
+							display: 'inline-block',
+							justifyContent: 'space-between',
+						}}
+					>
+						<b>LTR</b>
+						<br />
+						<br />
+						<GCPrimaryButton
+							onClick={() => {
+								triggerInitializeLTR();
+							}}
+							style={{ margin: '0 10px 10px 0', minWidth: 'unset' }}
+						>
+							Initialize
+						</GCPrimaryButton>
+						{ltrInitializedStatus &&
+							<div
+								style={{
+									minWidth: '200px',
+									display: 'inline-block'
+								}}
+							>
+								{ltrInitializedStatus === 200 ?
+									'Initialize request successful' :
+									`Initialize reqeust returned code ${ltrInitializedStatus}`
+								}
+							</div>
+						}
+						<br />
+						<GCPrimaryButton
+							onClick={() => {
+								triggerCreateModelLTR();
+							}}
+							style={{ margin: '0 10px 0 0', minWidth: 'unset' }}
+						>
+							Create Model
+						</GCPrimaryButton>
+						{ltrModelCreatedStatus &&
+							<div
+								style={{
+									minWidth: '200px',
+									display: 'inline-block'
+								}}
+							>
+								{ltrModelCreatedStatus === 200 ?
+									'Create model request successful' :
+									`Create model reqeust returned code ${ltrModelCreatedStatus}`
+								}
+							</div>
+						}
 					</div>
 				</BorderDiv>
 			</div>

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -121,6 +121,8 @@ const endpoints = {
 	saveOrgImageOverrideURL: '/api/gameChanger/saveOrgImageOverrideURL',
 	getFAQ: '/api/gamechanger/aboutGC/getFAQ',
 	compareDocumentPOST: '/api/gamechanger/analyticsTools/compareDocument',
+	initializeLTR: '/api/gamechanger/admin/initializeLTR',
+	createModelLTR: '/api/gamechanger/admin/createModelLTR',
 
 	exportHistoryDELETE: function (id) {
 		if (!id) {
@@ -954,6 +956,16 @@ export default class GameChangerAPI {
 
 	getFAQ = async () => {
 		const url = endpoints.getFAQ;
+		return axiosGET(this.axios, url);
+	};
+
+	initializeLTR = async () => {
+		const url = endpoints.initializeLTR;
+		return axiosGET(this.axios, url);
+	};
+
+	createModelLTR = async () => {
+		const url = endpoints.createModelLTR;
 		return axiosGET(this.axios, url);
 	};
 }

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -111,6 +111,7 @@ const endpoints = {
 	entitySearch: '/api/gamechanger/appSettings/entitySearch',
 	userFeedback: '/api/gamechanger/appSettings/userFeedback',
 	jiraFeedback: '/api/gamechanger/appSettings/jiraFeedback',
+	ltr: '/api/gamechanger/appSettings/ltr',
 	sendJiraFeedback: '/api/gamechanger/sendFeedback/jira',
 	getThumbnail: '/api/gameChanger/getThumbnail',
 	topicSearch: '/api/gamechanger/appSettings/topicSearch',
@@ -851,6 +852,16 @@ export default class GameChangerAPI {
 		const url = endpoints.sendJiraFeedback;
 		return axiosPOST(this.axios, url, body)
 	}
+
+	getLTRMode = async () => {
+		const url = endpoints.ltr;
+		return axiosGET(this.axios, url);
+	};
+
+	toggleLTR = async () => {
+		const url = endpoints.ltr;
+		return axiosPOST(this.axios, url, {});
+	};
 
 	getTopicSearchMode = async () => {
 		const url = endpoints.topicSearch;

--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -222,6 +222,9 @@ const PolicySearchHandler = {
 			let combinedSearch = await gameChangerAPI.getCombinedSearchMode();
 			combinedSearch = combinedSearch.data.value === 'true';
 
+			let ltr = await gameChangerAPI.getLTRMode();
+			ltr = ltr.data.value === 'true';
+
 			const resp = await gameChangerAPI.modularSearch({
 				cloneName: cloneData.clone_name,
 				searchText: searchObject.search,
@@ -240,7 +243,8 @@ const PolicySearchHandler = {
 					publicationDateFilter,
 					publicationDateAllTime,
 					includeRevoked,
-					archivedCongressSelected
+					archivedCongressSelected,
+					ltr
 				},
 				limit: 18,
 			});


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
Integrates new learn to rank (LTR) endpoints
- LTR toggle for admins
- LTR data added to elasticsearch query
- "Initialize" and "Create Model" buttons added to ML dashboard

## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
[UOT-121878](https://jira.di2e.net/browse/UOT-121878)

## Testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->
1. LTR toggle on admin page
2. LTR Buttons on ML dashboard provide confirmation that request was sent
3. "Create Model" button will disable once request is sent. Will also be disabled if there is any model process running in background
4. New data added to elastic query on search if LTR enabled:
 ``` "rescore": {
    "query": {
      "rescore_query": {
        "sltr": {
          "params": {
            "keywords": `${parsedQuery}`
          },
          "model": "ltr_model"
        }
      }
    }
  }
