### PR TITLE
task/UOT-113265 - Fix Reference Tables

### DIFF
--- a/frontend/src/utils/gamechangerUtils.js
+++ b/frontend/src/utils/gamechangerUtils.js
@@ -227,12 +227,21 @@ export const getReferenceListMetadataPropertyTable = (ref_list = []) => {
 		.map((x) => x.trim())
 		.chunk(4)
 		.value();
-	return _.map(trimmed, (x) => ({
-		References: x[0],
-		' ': x[1] || '',
-		'  ': x[2],
-		'   ': x[3],
-	}));
+	return _.map(trimmed, (x) => {
+		if (x.length === 2) {
+			return {
+				References: x[0],
+				' ': x[1] || '',
+			};
+		} else {
+			return {
+				References: x[0],
+				' ': x[1] || '',
+				'  ': x[2],
+				'   ': x[3],
+			};
+		}
+	});
 };
 
 export const getMetadataForPropertyTable = (item) => {


### PR DESCRIPTION
Gets rid of the extra columns on the references table on card backs, list view, doc explorer, and document details page

Before:
![image](https://user-images.githubusercontent.com/85301886/144641048-9ae39497-a2f9-4353-8f76-630820d5868b.png)


After: 
![image](https://user-images.githubusercontent.com/85301886/144640994-4ebce232-a550-4256-9959-8810bb9de91d.png)