### PR TITLE
bugfix/UOT-110127 - Fit Graph To Screen

### DIFF
--- a/frontend/src/components/details/documentDetailsPage.js
+++ b/frontend/src/components/details/documentDetailsPage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
 import GameChangerAPI from '../api/gameChanger-service-api';
 import Paper from '@material-ui/core/Paper';
@@ -55,6 +55,8 @@ const getGraphDataFull = (
 
 const DocumentDetailsPage = (props) => {
 	const { document, cloneData, userData, rawSearchResults } = props;
+
+	const ref = useRef(null);
 
 	const [runningQuery, setRunningQuery] = useState(false);
 	const [graphData, setGraphData] = useState({ nodes: [], edges: [] });
@@ -418,15 +420,14 @@ const DocumentDetailsPage = (props) => {
 					</Paper>
 				</div>
 				<div className={'graph-top-docs'}>
-					<div className={'section'}>
+					<div className={'section'} ref={ref}>
 						<GCAccordion
 							expanded={true}
 							header={'GRAPH VIEW (BETA)'}
 							backgroundColor={'rgb(238,241,242)'}
 						>
 							<MemoizedPolicyGraphView
-								width={1420}
-								height={670}
+								width={ref?.current?.clientWidth ? ref.current.clientWidth - 25 : undefined}
 								graphData={graphData}
 								runningSearchProp={runningQuery}
 								notificationCountProp={0}

--- a/frontend/src/components/graph/GraphNodeCluster2D.js
+++ b/frontend/src/components/graph/GraphNodeCluster2D.js
@@ -636,7 +636,7 @@ export default function GraphNodeCluster2D(props) {
 
 	const handleRenderLegend = () => {
 		return (
-			<div style={styles.legendKey}>
+			<div style={{ ...styles.legendKey, maxHeight: `calc(${graphHeight}px - 15px)` }}>
 				<div style={styles.legendRow} key="legendKeys">
 					<div style={{ fontWeight: 'bold' }}>Icon</div>
 					<div style={{ fontWeight: 'bold', marginLeft: '1em', width: '80%' }}>


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
Resizes graph canvas to fit screen on document details page. Prevents key legend from overflowing out of accordion.

At reasonable resolutions, width should fit the screen. Height will be a percentage of total viewport height, so it should take up more of the screen at high res and fit better at low res.

Note: Resize happens on page load, so changing window size will require a reload for graph to fit properly again.

Issues from before: 
![image](https://user-images.githubusercontent.com/85301886/145109854-b760c357-cd82-4cc6-bd03-7531e903014a.png)
--------------------
![image](https://user-images.githubusercontent.com/85301886/145109902-f0a5ed51-21d6-451c-8de6-5ffd5e1089f8.png)
--------------------
![image](https://user-images.githubusercontent.com/85301886/145110234-6887fabd-c94b-4d3c-a4a7-9c029e69db82.png)


## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
https://jira.di2e.net/browse/UOT-110127

## Testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->
Graphs on document details page should fit the accordion at various resolutions/zoom levels