### PR TITLE
UOT-123565: fixing QA search inconsistency

### DIFF
--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -1850,6 +1850,7 @@ class SearchUtility {
 	async getSentResults(searchText, userId) {
 		let sentResults = [];
 		try {
+			searchText = searchText.replace(/\?/g, '');
 			sentResults = await this.mlApi.getSentenceTransformerResults(searchText, userId);
 		} catch (e) {
 			this.logger.error(e, 'PQKLW5XN', userId);


### PR DESCRIPTION
Small change to remove '?' from queries before doing sentence search. in prod, "what is the lifecycle of a part?" does not return QA results but "what is the lifecycle of a part" does, so this change should make the results consistent. 
<img width="1353" alt="Screen Shot 2021-12-14 at 9 45 43 AM" src="https://user-images.githubusercontent.com/41591167/146025015-cc140381-bf06-4a8f-994c-7496497f99a8.png">
<img width="1327" alt="Screen Shot 2021-12-14 at 9 45 26 AM" src="https://user-images.githubusercontent.com/41591167/146025046-9f6101c7-a4dc-4fda-bb9a-71fdbc7ae284.png">
