### PR TITLE
Hotfix reference tables

### DIFF
--- a/frontend/src/utils/gamechangerUtils.js
+++ b/frontend/src/utils/gamechangerUtils.js
@@ -228,19 +228,24 @@ export const getReferenceListMetadataPropertyTable = (ref_list = []) => {
 		.chunk(4)
 		.value();
 	return _.map(trimmed, (x) => {
-		if (x.length === 2) {
-			return {
-				References: x[0],
-				' ': x[1] || '',
-			};
-		} else {
-			return {
-				References: x[0],
-				' ': x[1] || '',
-				'  ': x[2],
-				'   ': x[3],
-			};
-		}
+		let y = {};
+		x.forEach((element, index) => {
+			switch (index) {
+				default:
+					y['References'] = element;
+					break;
+				case 1:
+					y[' '] = element;
+					break;
+				case 2:
+					y['  '] = element;
+					break;
+				case 3:
+					y['   '] = element;
+					break;
+			}
+		});
+		return y;
 	});
 };
 


### PR DESCRIPTION
Misunderstood what was going on first time I tried to fix this. Reference table will look correct now with varying numbers of references (no blank cells unless at the end of a row, first row will shrink if less than 4 items). Can be found on card backs, document details page, and document explorer.

![image](https://user-images.githubusercontent.com/85301886/146088397-74c6251d-3f2b-46c5-95f3-293497e847ba.png)

![image](https://user-images.githubusercontent.com/85301886/146088422-4fa4d037-5808-461c-bdfa-25a01b94a939.png)
