### PR TITLE
add product field to jira feedback

### DIFF
--- a/backend/node_app/config/constants.js
+++ b/backend/node_app/config/constants.js
@@ -227,6 +227,7 @@ module.exports = Object.freeze({
 		domain: process.env.JIRA_DOMAIN,
 		project_key: process.env.JIRA_PROJECT_KEY,
 		rating_id: process.env.JIRA_RATING_ID,
+		advana_product: process.env.JIRA_ADVANA_PRODUCT,
 		feedbackType: process.env.JIRA_FEEDBACK_TYPE
 	},
 });

--- a/backend/node_app/controllers/feedbackController.js
+++ b/backend/node_app/controllers/feedbackController.js
@@ -116,6 +116,9 @@ class FeedbackController {
 					[JIRA_CONFIG.rating_id]: {
 						'value': rating + ''
 					},
+					[JIRA_CONFIG.advana_product]: {
+						'value': 'GAMECHANGER'
+					},
 					'issuetype': {
 						'name': JIRA_CONFIG.feedbackType
 					}


### PR DESCRIPTION
## Description
Adds the custom 'product' field to the Jira feedback to help separate GC feedback from other Advana products' feedback. 

Also includes new env var: JIRA_ADVANA_PRODUCT