### PR TITLE
Task/UOT-125161 - All Docs Filter / Graph URL

### DIFF
--- a/frontend/src/components/graph/policyGraphView.js
+++ b/frontend/src/components/graph/policyGraphView.js
@@ -1374,28 +1374,38 @@ export default function PolicyGraphView(props) {
 	 * Graph Legend Functions
 	 */
 
+	const handleLegendAllDocsClick = (_, legendKey) => {
+		setOrgTypesSelected(
+			orgTypesSelected.includes(legendKey) ?
+				orgTypesSelected.filter(type => type === 'Topic' || type === 'Entity') :
+				[
+					...orgTypesSelected,
+					...Object.keys(legendData).filter(type =>
+						type !== 'Topic' && type !== 'Entity' && !orgTypesSelected.includes(type)
+					), legendKey
+				]
+		);
+
+		setNodeGroupMenuOpen(false);
+		setNodeGroupMenuTarget(null);
+		setNodeGroupMenuLabel('');
+	};
+
 	const renderNodeLegendItems = () => {
-		return (!runningSearch && Object.keys(legendData).sort().map((key) => {
-			return (
-				<GCTooltip
-					key={key}
-					title={`${docOrgNumbers[key]} node${
-						docOrgNumbers[key] > 1 ? 's' : ''
-					} associated`}
-					arrow
-					enterDelay={30}
-				>
+		return (!runningSearch &&
+			<>
+				{(Object.keys(legendData).includes('Topic') || Object.keys(legendData).includes('Entity')) && // Don't display All Documents filter if filters are only documents
 					<StyledLegendClickable
-						key={legendData[key].name}
+						key={'All Documents'}
 						onClick={(event) =>
-							handleLegendNodeClick(event.target, key)
+							handleLegendAllDocsClick(event.target, 'All Documents')
 						}
 						typesSelected={orgTypesSelected}
-						type={key}
+						type={'All Documents'}
 					>
 						<div
 							style={{
-								backgroundColor: legendData[key].color,
+								backgroundColor: '#6eb8cc',
 								width: '1em',
 								height: '1em',
 								borderRadius: '50%',
@@ -1403,12 +1413,46 @@ export default function PolicyGraphView(props) {
 							}}
 						></div>
 						<div style={{ marginLeft: '2em', width: '80%' }}>
-							{legendData[key].name}
+							All Documents
 						</div>
 					</StyledLegendClickable>
-				</GCTooltip>
-			);
-		}));
+				}
+				{Object.keys(legendData).sort((x, y) => x === 'All Documents' ? -1 : y === 'All Documents' ? 1 : 0).map((key) => {
+					return (
+						<GCTooltip
+							key={key}
+							title={`${docOrgNumbers[key]} node${
+								docOrgNumbers[key] > 1 ? 's' : ''
+							} associated`}
+							arrow
+							enterDelay={30}
+						>
+							<StyledLegendClickable
+								key={legendData[key].name}
+								onClick={(event) =>
+									handleLegendNodeClick(event.target, key)
+								}
+								typesSelected={orgTypesSelected}
+								type={key}
+							>
+								<div
+									style={{
+										backgroundColor: legendData[key].color,
+										width: '1em',
+										height: '1em',
+										borderRadius: '50%',
+										marginTop: '4px',
+									}}
+								></div>
+								<div style={{ marginLeft: '2em', width: '80%' }}>
+									{legendData[key].name}
+								</div>
+							</StyledLegendClickable>
+						</GCTooltip>
+					);
+				})}
+			</>
+		);
 	};
 
 	const handleLegendNodeClick = (target, legendKey) => {
@@ -1419,10 +1463,18 @@ export default function PolicyGraphView(props) {
 			!orgTypesSelected.includes(legendKey)
 		);
 
+		const newOrgTypesSelected = orgTypesSelected.includes(legendKey) ?
+			orgTypesSelected.filter(type => type !== legendKey) :
+			[...orgTypesSelected, legendKey];
+
+		const allOrgTypesExceptTopicAndEntity =
+			Object.keys(legendData).filter(type => type !== 'Topic' && type !== 'Entity');
+		const allCurrentOrgTypesExceptTopicAndEntity =
+			newOrgTypesSelected.filter(type => type !== 'Topic' && type !== 'Entity' && type !== 'All Documents');
+
 		setOrgTypesSelected(
-			orgTypesSelected.includes(legendKey) ?
-				orgTypesSelected.filter(type => type !== legendKey) :
-				[...orgTypesSelected, legendKey]
+			_.isEqual(allOrgTypesExceptTopicAndEntity.sort(), allCurrentOrgTypesExceptTopicAndEntity.sort()) ?
+				[...newOrgTypesSelected, 'All Documents'] : newOrgTypesSelected.filter(type => type !== 'All Documents')
 		);
 
 		if (orgTypesSelected.includes(legendKey)) {

--- a/frontend/src/components/graph/policyGraphView.js
+++ b/frontend/src/components/graph/policyGraphView.js
@@ -1667,7 +1667,10 @@ export default function PolicyGraphView(props) {
 
 		if (
 			orgTypesSelected.length !== 0 &&
-			(!orgTypesSelected.includes(start.orgType) || !orgTypesSelected.includes(end.orgType))
+			(
+				!orgTypesSelected.includes(start.orgType || start.label) ||
+				!orgTypesSelected.includes(end.orgType || end.label)
+			)
 		) {
 			return getLinkColor(link, HIDDEN_NODE_ALPHA);
 		} else {

--- a/frontend/src/components/mainView/ViewHeader.js
+++ b/frontend/src/components/mainView/ViewHeader.js
@@ -174,21 +174,28 @@ const ViewHeader = (props) => {
 
 	const handleChangeView = (event) => {
 		const {target: { value }} = event;
+		const params = new URLSearchParams(window.location.hash.replace(`#/${state.cloneData.url.toLowerCase()}`, ''));
 		switch(value) {
 			case 'List':
 				setState(dispatch, {currentViewName: 'Card', listView: true});
+				params.delete('view');
 				break;
 			case 'Grid':
 				setState(dispatch, {currentViewName: 'Card', listView: false});
+				params.delete('view');
 				break;
 			case 'Graph':
 				setState(dispatch, {currentViewName: value, runGraphSearch: true});
+				params.set('view', 'graph');
 				break;
 			case 'Explorer':
 			default:
 				setState(dispatch, {currentViewName: value});
+				params.delete('view');
 		}
-		setDropdownValue(value)
+		setDropdownValue(value);
+		const linkString = `/#/${state.cloneData.url.toLowerCase()}?${params}`;
+		window.history.pushState(null, document.title, linkString);
 	}
 
 	return (

--- a/frontend/src/components/modules/policy/policyMainViewHandler.js
+++ b/frontend/src/components/modules/policy/policyMainViewHandler.js
@@ -18,6 +18,7 @@ import Pagination from 'react-js-pagination';
 import GCTooltip from '../../common/GCToolTip';
 import GetQAResults from '../default/qaResults';
 import {
+	getQueryVariable,
 	getTrackingNameForFactory,
 	RESULTS_PER_PAGE,
 	StyledCenterContainer,
@@ -302,7 +303,12 @@ const PolicyMainViewHandler = {
 			// Do nothing
 		}
 
-		setState(dispatch, { adminTopics: topics });
+		setState(
+			dispatch,
+			getQueryVariable('view', window.location.hash.toString()) === 'graph' ?
+				{ adminTopics: topics, currentViewName: 'Graph', runGraphSearch: true } :
+				{ adminTopics: topics }
+		);
 		// handlePubs(pubs, state, dispatch);
 		handleSources(state, dispatch);
 		handlePopPubs(pop_pubs, pop_pubs_inactive, state, dispatch);

--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -811,6 +811,9 @@ const PolicySearchHandler = {
 			  ).join('_')
 			: undefined;
 
+		const currentParams =
+			new URLSearchParams(window.location.hash.replace(`#/${state.cloneData.url.toLowerCase()}`, ''));
+
 		const params = new URLSearchParams();
 		if (searchText) params.append('q', searchText);
 		if (offset) params.append('offset', String(offset)); // 0 is default
@@ -823,6 +826,7 @@ const PolicySearchHandler = {
 		if (includeRevoked) params.append('revoked', String(includeRevoked)); // false is default
 		if (categoriesText !== undefined)
 			params.append('categories', categoriesText); // '' is different than undefined
+		if (currentParams.get('view') === 'graph') params.append('view', 'graph');
 
 		const linkString = `/#/${state.cloneData.url.toLowerCase()}?${params}`;
 


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
- Add "All Documents" filter to graph view
- Additional url param for direct linking to graph view

All Documents appears at top of filters list only if Topic/Entity is also in filters (view on doc details page)
![image](https://user-images.githubusercontent.com/85301886/150828046-571501d4-47e7-475f-ad22-1ef511099fed.png)

All Documents toggles all filters except Topic/Entity. Manually clicking through all the document filters will also toggle All Documents on/off.

Changing to graph view adds `&view=graph` to url, use this to link directly to graph view. Changing to a different view will remove the param.


## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
https://jira.di2e.net/browse/UOT-125161
https://jira.di2e.net/browse/UOT-125166