### PR TITLE
Task/homepage performance

### DIFF
--- a/backend/node_app/controllers/appStatsController.js
+++ b/backend/node_app/controllers/appStatsController.js
@@ -165,7 +165,6 @@ class AppStatsController {
 				daysAgo = 3,
 				internalUsers = [],
 				blacklist = [],
-				doGetAvgSearches = true
 			} = req.body;
 
 			const results = {
@@ -181,9 +180,7 @@ class AppStatsController {
 					blacklist: blacklist
 				}
 			};
-			if(doGetAvgSearches){
-				results.data.avgSearchesPerSession = await this.getAvgSearchesPerSession(3, connection);
-			}
+			results.data.avgSearchesPerSession = await this.getAvgSearchesPerSession(3, connection);
 			results.data.topSearches.data = await this.getTopSearches(cloneData, daysAgo, internalUsers, blacklist, 10, connection);
 			let cleanedTopSearches = [];
 			results.data.topSearches.data.forEach((d) => {

--- a/backend/node_app/controllers/appStatsController.js
+++ b/backend/node_app/controllers/appStatsController.js
@@ -164,7 +164,8 @@ class AppStatsController {
 				cloneData = {},
 				daysAgo = 3,
 				internalUsers = [],
-				blacklist = []
+				blacklist = [],
+				doGetAvgSearches = true
 			} = req.body;
 
 			const results = {
@@ -180,7 +181,9 @@ class AppStatsController {
 					blacklist: blacklist
 				}
 			};
-			results.data.avgSearchesPerSession = await this.getAvgSearchesPerSession(3, connection);
+			if(doGetAvgSearches){
+				results.data.avgSearchesPerSession = await this.getAvgSearchesPerSession(3, connection);
+			}
 			results.data.topSearches.data = await this.getTopSearches(cloneData, daysAgo, internalUsers, blacklist, 10, connection);
 			let cleanedTopSearches = [];
 			results.data.topSearches.data.forEach((d) => {

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -376,14 +376,22 @@ export default class GameChangerAPI {
 	thumbnailStorageDownloadPOST = async (filenames, folder, cloneData, cancelToken) => {
 		const s3Bucket = cloneData?.s3_bucket ?? 'advana-data-zone/bronze';
 		const url = endpoints.thumbnailStorageDownloadPOST;
+		if(cancelToken){
+			return axiosPOST(
+				this.axios,
+				url,
+				{ filenames, folder, clone_name: cloneData.clone_name, dest: s3Bucket },
+				{ 
+					timeout: 0,
+					cancelToken: cancelToken?.token ? cancelToken.token : {}
+				}
+			);
+		}
 		return axiosPOST(
 			this.axios,
 			url,
 			{ filenames, folder, clone_name: cloneData.clone_name, dest: s3Bucket },
-			{ 
-				timeout: 0,
-				cancelToken: cancelToken?.token ? cancelToken.token : {}
-			}
+			{ timeout: 0 }
 		);
 	};
 

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -382,7 +382,7 @@ export default class GameChangerAPI {
 			{ filenames, folder, clone_name: cloneData.clone_name, dest: s3Bucket },
 			{ 
 				timeout: 0,
-				cancelToken: cancelToken.token ? cancelToken.token : {}
+				cancelToken: cancelToken?.token ? cancelToken.token : {}
 			}
 		);
 	};

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -382,7 +382,7 @@ export default class GameChangerAPI {
 			{ filenames, folder, clone_name: cloneData.clone_name, dest: s3Bucket },
 			{ 
 				timeout: 0,
-				cancelToken: cancelToken.token
+				cancelToken: cancelToken.token ? cancelToken.token : {}
 			}
 		);
 	};

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -373,15 +373,17 @@ export default class GameChangerAPI {
 		});
 	};
 
-	thumbnailStorageDownloadPOST = async (filenames, folder, cloneData) => {
+	thumbnailStorageDownloadPOST = async (filenames, folder, cloneData, cancelToken) => {
 		const s3Bucket = cloneData?.s3_bucket ?? 'advana-data-zone/bronze';
-		//const s3Bucket = 'advana-raw-zone';
 		const url = endpoints.thumbnailStorageDownloadPOST;
 		return axiosPOST(
 			this.axios,
 			url,
 			{ filenames, folder, clone_name: cloneData.clone_name, dest: s3Bucket },
-			{ timeout: 0 }
+			{ 
+				timeout: 0,
+				cancelToken: cancelToken.token
+			}
 		);
 	};
 

--- a/frontend/src/components/mainView/MainView.js
+++ b/frontend/src/components/mainView/MainView.js
@@ -39,17 +39,13 @@ const MainView = (props) => {
 
 	useEffect(() => {
 		return function cleanUp(){
-			console.log('running clean up')
 			cancelToken.cancel('canceled axios with cleanup');
 			cancelToken = axios.CancelToken.source();
 		}
 	},[])
 
 	useEffect(() => {
-		console.log('state.runSearch: ', state.runningSearch);
 		if(state.runningSearch && cancelToken) {
-			const cd = new Date();
-			console.log('CANCELING AXIOS: ', `${cd.getMinutes()}.${cd.getSeconds()}.${cd.getMilliseconds()}`);
 			cancelToken.cancel('canceled axios request from search run');
 			cancelToken = axios.CancelToken.source();
 		};

--- a/frontend/src/components/mainView/MainView.js
+++ b/frontend/src/components/mainView/MainView.js
@@ -27,7 +27,6 @@ import { useBottomScrollListener } from 'react-bottom-scroll-listener';
 
 const gameChangerAPI = new GameChangerAPI();
 let cancelToken = axios.CancelToken.source();
-cancelToken.test = new Date();
 
 const MainView = (props) => {
 	const { context } = props;
@@ -50,7 +49,7 @@ const MainView = (props) => {
 		console.log('state.runSearch: ', state.runningSearch);
 		if(state.runningSearch && cancelToken) {
 			const cd = new Date();
-			console.log('CANCELING AXIOS: ', `${cd.getMinutes()}.${cd.getSeconds()}.${cd.getMilliseconds()} --- ${cancelToken.test.getMilliseconds()}`);
+			console.log('CANCELING AXIOS: ', `${cd.getMinutes()}.${cd.getSeconds()}.${cd.getMilliseconds()}`);
 			cancelToken.cancel('canceled axios request from search run');
 			cancelToken = axios.CancelToken.source();
 		};

--- a/frontend/src/components/modules/default/defaultMainViewHandler.js
+++ b/frontend/src/components/modules/default/defaultMainViewHandler.js
@@ -123,44 +123,6 @@ const checkForTinyURL = async (location) => {
 	}
 };
 
-const getTrendingSearches = (cloneData) => {
-	const daysAgo = 7;
-	let internalUsers = [];
-	let blacklist = [];
-
-	gameChangerAPI
-		.getInternalUsers()
-		.then(({ data }) => {
-			data.forEach((d) => {
-				internalUsers.push(d.username);
-			});
-
-			gameChangerAPI
-				.getTrendingBlacklist()
-				.then(({ data }) => {
-					data.forEach((d) => {
-						blacklist.push(d.search_text);
-					});
-
-					gameChangerAPI
-						.getAppStats({ cloneData, daysAgo, internalUsers, blacklist, doGetAvgSearches: false })
-						.then(({ data }) => {
-							localStorage.setItem(
-								`trending${cloneData.clone_name}Searches`,
-								JSON.stringify(data.data.topSearches.data)
-							);
-						})
-						.catch((e) => {
-							console.log('error with getting trending: ' + e);
-						});
-				})
-				.catch((e) => console.log('error with getting blacklist: ' + e));
-		})
-		.catch((e) => {
-			console.log('error getting internal users: ' + e);
-		});
-};
-
 const handleDidYouMeanClicked = (didYouMean, state, dispatch) => {
 	trackEvent(
 		getTrackingNameForFactory(state.cloneData.clone_name),

--- a/frontend/src/components/modules/default/defaultMainViewHandler.js
+++ b/frontend/src/components/modules/default/defaultMainViewHandler.js
@@ -143,7 +143,7 @@ const getTrendingSearches = (cloneData) => {
 					});
 
 					gameChangerAPI
-						.getAppStats({ cloneData, daysAgo, internalUsers, blacklist })
+						.getAppStats({ cloneData, daysAgo, internalUsers, blacklist, doGetAvgSearches: false })
 						.then(({ data }) => {
 							localStorage.setItem(
 								`trending${cloneData.clone_name}Searches`,

--- a/frontend/src/components/modules/policy/policyMainViewHandler.js
+++ b/frontend/src/components/modules/policy/policyMainViewHandler.js
@@ -190,8 +190,6 @@ const handlePopPubs = async (pop_pubs, pop_pubs_inactive, state, dispatch, cance
 		}));
 		setState(dispatch, { searchMajorPubs: filteredPubs });
 
-		const cd = new Date();
-		console.log('DOWNLOADING PUBS: ', `${cd.getMinutes()}.${cd.getSeconds()}.${cd.getMilliseconds()}`);
 		for (let i = 0; i < filteredPubs.length; i++) {
 			gameChangerAPI
 				.thumbnailStorageDownloadPOST(
@@ -210,7 +208,9 @@ const handlePopPubs = async (pop_pubs, pop_pubs_inactive, state, dispatch, cance
 						}
 					});
 					setState(dispatch, { searchMajorPubs: filteredPubs });
-				}).catch(e => console.log(e));
+				}).catch(e => {
+					//Do nothing
+				});
 		}
 	} catch (e) {
 		//Do nothing
@@ -231,8 +231,6 @@ const handleSources = async (state, dispatch, cancelToken) => {
 			let filename = item.image_link.split('/').pop();
 			return { img_filename: filename };
 		});
-		const cd = new Date();
-		console.log('DOWNLOADING SOURCES: ', `${cd.getMinutes()}.${cd.getSeconds()}.${cd.getMilliseconds()}`);
 		for (let i = 0; i < thumbnailList.length; i++) {
 			gameChangerAPI
 				.thumbnailStorageDownloadPOST(
@@ -259,7 +257,9 @@ const handleSources = async (state, dispatch, cancelToken) => {
 						}
 					});
 					setState(dispatch, { crawlerSources });
-				}).catch(e => console.log(e));
+				}).catch(e => {
+					//Do nothing
+				});
 		}
 	} catch (e) {
 		//Do nothing

--- a/frontend/src/components/searchMetrics/GCSideBar.js
+++ b/frontend/src/components/searchMetrics/GCSideBar.js
@@ -433,6 +433,8 @@ export default function SideBar(props) {
 									orgSources[idx].imgSrc = DefaultSeal;
 								}
 							});
+						}).catch(e => {
+							//Do nothing
 						});
 				}
 				setOrgSources(orgSources);


### PR DESCRIPTION
## Description
Cleans up some unused homepage code and adds cancel tokens to some lengthy homepage API calls to stop them when leaving the homepage.

## Ticket
UOT-126981

## Testing Instructions
Make a few searches and go back and forth between the homepage to make sure things still run smoothly. Should see small performance gains when going directly to a search from a query URL. 