### PR TITLE
task/UOT-128739 - Nodes in Group Menu

### DIFF
--- a/frontend/src/components/graph/GraphNodeCluster2D.js
+++ b/frontend/src/components/graph/GraphNodeCluster2D.js
@@ -714,7 +714,9 @@ export default function GraphNodeCluster2D(props) {
 	const renderNodeGroupMenu = () => {
 		const nodesInGroup = graphData.nodes.filter((node) => {
 			return (
-				node.display_org_s === nodeGroupMenuLabelProp || nodeGroupMenuLabel
+				node.display_org_s ?
+					node.display_org_s === nodeGroupMenuLabelProp || nodeGroupMenuLabel :
+					node.label === nodeGroupMenuLabelProp || nodeGroupMenuLabel
 			);
 		});
 		return (
@@ -752,9 +754,10 @@ export default function GraphNodeCluster2D(props) {
 								}}
 							>
 								{nodesInGroup.map((node) => {
+									let isTopicOrEntityNode = node.label === 'Topic' || node.label === 'Entity';
 									return (
 										<GCTooltip
-											title={node.display_title_s}
+											title={(isTopicOrEntityNode || node.label === 'UKN_Document') ? '' : node.display_title_s}
 											arrow
 											style={{ zIndex: 99999 }}
 										>
@@ -772,7 +775,7 @@ export default function GraphNodeCluster2D(props) {
 													handleNodeHover(null);
 												}}
 											>
-												{`${node.doc_type} ${node.doc_num}`}
+												{isTopicOrEntityNode ? node.name : `${node.doc_type} ${node.doc_num}`}
 											</StyledNodeGroupNode>
 										</GCTooltip>
 									);


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
Nodes in Group menu will show for the entity, topic, and unknown document filters (previously popup would be empty).

Hovering over each list item works as normal - graph focuses on that node, clicking the list item brings up the node menu.

## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
https://jira.di2e.net/browse/UOT-128739

![image](https://user-images.githubusercontent.com/85301886/151253815-8004557f-0953-4ac9-9b74-41e3cb2c9c51.png)
