### PR TITLE
results page no longer shows at bottom of homepage when no results

### DIFF
--- a/frontend/src/components/modules/policy/policyMainViewHandler.js
+++ b/frontend/src/components/modules/policy/policyMainViewHandler.js
@@ -723,7 +723,7 @@ const PolicyMainViewHandler = {
 				<div key={'cardView'} style={{ marginTop: hideTabs ? 40 : 'auto' }}>
 					<div>
 						<div id="game-changer-content-top" />
-						{!loading && (
+						{!loading && docSearchResults.length > 0 && (
 							<StyledCenterContainer showSideFilters={showSideFilters}>
 								{showSideFilters && (
 									<div className={'left-container'}>
@@ -952,7 +952,7 @@ const PolicyMainViewHandler = {
 								</GCTooltip>
 							</div>
 						)}
-						{Permissions.isGameChangerAdmin() && !loading && (
+						{Permissions.isGameChangerAdmin() && !loading && docSearchResults.length > 0 && (
 							<div style={styles.cachedResultIcon}>
 								<i
 									style={{ cursor: 'pointer' }}


### PR DESCRIPTION
## Description
Stops the results page from showing at the bottom of the homepage when there are no results. 

## Testing
Make a search that has no results then scroll down to make sure the results page isn't displayed (filters and what not)