### PR TITLE
Hotfix/uot 130865

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -280,10 +280,14 @@ app.all('/api/*/admin/*', async function (req, res, next) {
 	if (req.permissions.includes('Gamechanger Admin') || req.permissions.includes('Webapp Super Admin')) {
 		next();
 	} else {
-		const signatureFromApp = req.get('x-ua-signature');
-		const userToken = Base64.stringify(CryptoJS.HmacSHA256(req.path, process.env.ML_WEB_TOKEN))
-		if(req.get('SSL_CLIENT_S_DN_CN')==='ml-api' &&  signatureFromApp=== userToken){
-			next();
+		
+		if(req.get('SSL_CLIENT_S_DN_CN')==='ml-api'){
+			
+			const signatureFromApp = req.get('x-ua-signature');
+			const userToken = Base64.stringify(CryptoJS.HmacSHA256(req.path, process.env.ML_WEB_TOKEN))
+			if (signatureFromApp === userToken){
+				next();
+			}
 		}
 		else{
 			res.sendStatus(403);

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -282,7 +282,7 @@ const App = () => {
 	useEffect(() => {
 		const initialize = async () => {
 			if (isDecoupled) {
-				GCAuth.refreshUserToken(
+				await GCAuth.refreshUserToken(
 					() => setTokenLoaded(true),
 					() => setTokenLoaded(true)
 				);

--- a/frontend/src/components/common/GCAuth.js
+++ b/frontend/src/components/common/GCAuth.js
@@ -92,8 +92,8 @@ class GCAuth {
 		}
 	}
 
-	static refreshUserToken(callback, errCallback) {
-		axios
+	static async refreshUserToken(callback, errCallback) {
+		await axios
 			.post(USER_TOKEN_ENDPOINT)
 			.then((response) => {
 				this.saveUser(response.data.token);


### PR DESCRIPTION
Issue on decoupled was the application wasnt waiting for local storage to be set with the token leading to startup requests having different tokens then the backend.  Also fixed a issue where if the ML_WEB_TOKEN was not set for the coupled application it could create an error for non ml-api users