### PR TITLE
Task/UOT-132470 - Fix Reference Nodes

### DIFF
--- a/frontend/src/components/graph/defaultGraphView.js
+++ b/frontend/src/components/graph/defaultGraphView.js
@@ -21,6 +21,7 @@ const getGraphData = async (
 	setGraph,
 	setNoSearches,
 	setNodeLimit,
+	setMockedFromES,
 	state,
 	dispatch
 ) => {
@@ -92,6 +93,7 @@ const getGraphData = async (
 			setNoSearches(true);
 		}
 		setNodeLimit(graphResp?.data?.query?.limit);
+		setMockedFromES(graphResp?.data?.query.query === 'Mocked from ES');
 	} catch (err) {
 		console.log(err);
 	}
@@ -109,6 +111,7 @@ const DefaultGraphView = (props) => {
 	const [timeFound, setTimeFound] = React.useState('0');
 	const [numOfEdges, setNumOfEdges] = React.useState(0);
 	const [nodeLimit, setNodeLimit] = useState();
+	const [mockedFromES, setMockedFromES] = useState(false);
 
 	const [width, setWidth] = React.useState(
 		window.innerWidth * (((state.showSideFilters ? 68.5 : 90.5) - 1) / 100)
@@ -131,6 +134,7 @@ const DefaultGraphView = (props) => {
 				setGraph,
 				setNoSearches,
 				setNodeLimit,
+				setMockedFromES,
 				state,
 				dispatch
 			);
@@ -178,6 +182,7 @@ const DefaultGraphView = (props) => {
 					setGraphResultsFound(false);
 				}}
 				nodeLimit={nodeLimit}
+				mockedFromES={mockedFromES}
 			/>
 		</div>
 	);

--- a/frontend/src/components/graph/policyGraphView.js
+++ b/frontend/src/components/graph/policyGraphView.js
@@ -380,6 +380,7 @@ export default function PolicyGraphView(props) {
 		selectedDocuments = [],
 		loadAll,
 		nodeLimit,
+		mockedFromES,
 	} = props;
 
 	const graph2DRef = useRef();
@@ -1213,6 +1214,19 @@ export default function PolicyGraphView(props) {
 		});
 
 		const graphData = resp.data;
+
+		if (mockedFromES) {
+			// when results are mocked from ES, node ids are changed which causes a mismatch with the neo4j query above
+			// this matches based on doc_id and sets the mocked node's id to the id from neo4j
+			graph.nodes.forEach(mockedNode => {
+				graphData.nodes.forEach(node => {
+					if (mockedNode.doc_id === node.doc_id) {
+						mockedNode.id = node.id;
+					}
+				});
+			});
+		}
+
 		const nodeIds = graph.nodes.map((node) => {
 			return node.id;
 		});


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
This fix applies to the reference nodes button on document nodes. Previously, if the results were mocked from ES (#results > PULL_NODES_FROM_NEO4J_MAX_LIMIT), then showing reference nodes would bring up a disconnected graph with a duplicate root node.

Before - loading reference nodes on EO 13953 duplicates the node and shows references on a disconnected graph:
![image](https://user-images.githubusercontent.com/85301886/154556330-4938223a-91c1-4a7d-b5a3-f9fb94b172c7.png)

After - reference nodes are connected to the original node, no longer creates duplicate:
![image](https://user-images.githubusercontent.com/85301886/154556866-8c1295b2-bb4f-43f9-993f-c74e96c3f1f2.png)

## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
https://jira.di2e.net/browse/UOT-132470

## Testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->
Test loading reference nodes on any node in a graph that is mocking results from ES (>500 results, must show warning banner at top of graph as shown in screenshots)