### PR TITLE
task/UOT-132469 - Center Node Context Menu

### DIFF
--- a/frontend/src/components/details/documentDetailsPage.js
+++ b/frontend/src/components/details/documentDetailsPage.js
@@ -431,14 +431,11 @@ const DocumentDetailsPage = (props) => {
 								width={ref?.current?.clientWidth ? ref.current.clientWidth - 25 : undefined}
 								graphData={graphData}
 								runningSearchProp={runningQuery}
-								notificationCountProp={0}
 								setDocumentsFound={() => {}}
 								setTimeFound={() => {}}
 								cloneData={cloneData}
-								expansionTerms={false}
 								setNumOfEdges={() => {}}
 								dispatch={{}}
-								showSideFilters={false}
 								showBasic={false}
 								searchText={''}
 								detailsView={true}

--- a/frontend/src/components/graph/GraphNodeCluster2D.js
+++ b/frontend/src/components/graph/GraphNodeCluster2D.js
@@ -41,11 +41,11 @@ const edgePatterns = [[], ...shuffleArray(EDGE_PATTERNS)];
 
 const styles = {
 	loading: {
-		position: 'absolute',
+		position: 'fixed',
 		zIndex: '99',
 		left: '50%',
 		top: '50%',
-		transform: 'translate(-50%, -50%)',
+		transform: 'translate(50%, -30%)',
 	},
 	legendKey: {
 		margin: '8px',
@@ -1555,7 +1555,7 @@ export default function GraphNodeCluster2D(props) {
 	};
 
 	return (
-		<div id={'graph2dContainer'} style={{ ...style, textAlign: 'left' }}>
+		<div id={'graph2dContainer'} style={{ ...style, textAlign: 'left', position: 'relative' }}>
 			{showSettingsMenu && (
 				<div
 					style={{

--- a/frontend/src/components/graph/defaultGraphView.js
+++ b/frontend/src/components/graph/defaultGraphView.js
@@ -165,14 +165,11 @@ const DefaultGraphView = (props) => {
 				height={height}
 				graphData={graph}
 				runningSearchProp={runningSearch}
-				notificationCountProp={state.notifications.length}
 				setDocumentsFound={setDocumentsFound}
 				setTimeFound={setTimeFound}
 				cloneData={state.cloneData}
-				expansionTerms={state.hasExpansionTerms}
 				setNumOfEdges={setNumOfEdges}
 				dispatch={dispatch}
-				showSideFilters={state.showSideFilters}
 				searchText={state.searchText}
 				selectedDocuments={state.selectedDocumentsForGraph}
 				loadAll={() => {

--- a/frontend/src/components/graph/defaultGraphView.js
+++ b/frontend/src/components/graph/defaultGraphView.js
@@ -173,9 +173,7 @@ const DefaultGraphView = (props) => {
 				searchText={state.searchText}
 				selectedDocuments={state.selectedDocumentsForGraph}
 				loadAll={() => {
-					const newSearchSettings = _.cloneDeep(state.searchSettings);
-					newSearchSettings.loadAll = true;
-					setState(dispatch, { searchSettings: newSearchSettings, runGraphSearch: true });
+					setState(dispatch, { searchSettings: { ...state.searchSettings, loadAll: true }, runGraphSearch: true });
 					setGraphResultsFound(false);
 				}}
 				nodeLimit={nodeLimit}

--- a/frontend/src/components/graph/policyGraphView.js
+++ b/frontend/src/components/graph/policyGraphView.js
@@ -365,14 +365,11 @@ export default function PolicyGraphView(props) {
 		height,
 		graphData,
 		runningSearchProp,
-		notificationCountProp = 0,
 		setDocumentsFound = (docs) => {},
 		setTimeFound = (time) => {},
-		expansionTerms = false,
 		cloneData,
 		setNumOfEdges = (num) => {},
 		dispatch = () => {},
-		showSideFilters = false,
 		searchText = '',
 		showBasic = false,
 		hierarchyView = false,
@@ -385,7 +382,6 @@ export default function PolicyGraphView(props) {
 
 	const graph2DRef = useRef();
 
-	const [notificationCount, setNotificationCount] = React.useState(0);
 	const [show2DView, setShow2DView] = React.useState(true);
 	const [contextOpen, setContextOpen] = React.useState(false);
 	const [shouldRender, setShouldRender] = React.useState(true);
@@ -401,7 +397,6 @@ export default function PolicyGraphView(props) {
 	});
 	const [docOrgNumbers, setDocOrgNumbers] = React.useState({});
 	const [orgTypesSelected, setOrgTypesSelected] = React.useState([]);
-	const [mouseXY, setMouseXY] = React.useState({ x: 0, y: 0 });
 	const [selectedID, setSelectedID] = React.useState(null);
 	const [shouldCenter, setShouldCenter] = React.useState(true);
 	const [showGraphCard, setShowGraphCard] = React.useState(false);
@@ -448,10 +443,6 @@ export default function PolicyGraphView(props) {
 			//setRunSimulation(true);
 		}
 	}, [runningSearchProp, runningSearch]);
-
-	useEffect(() => {
-		setNotificationCount(notificationCountProp);
-	}, [notificationCountProp]);
 
 	useEffect(() => {
 		if (!graph || !graph.nodes) return;
@@ -636,11 +627,7 @@ export default function PolicyGraphView(props) {
 		graph2DRef.current.zoom(ZOOM_LIMIT, 500);
 		setZoom(ZOOM_LIMIT);
 
-		sleep(500).then(() => {
-			const { x, y } = graph2DRef.current.graph2ScreenCoords(node.x, node.y);
-			setMouseXY({ x: x, y: y });
-			setContextOpen(true);
-		});
+		sleep(500).then(() => setContextOpen(true));
 
 		lockNodeInPlace(node, true);
 	};
@@ -648,16 +635,8 @@ export default function PolicyGraphView(props) {
 	const showNodeContextMenu = () => {
 		const myStyle = {
 			position: 'absolute',
-			top: `${
-				mouseXY.y +
-				154 +
-				notificationCount * 50 +
-				(expansionTerms ? 41 : 0) +
-				(detailsView ? -175 : 0)
-			}px`,
-			left: `${
-				mouseXY.x - 20 + (showSideFilters ? 372 : detailsView ? -100 : 0)
-			}px`,
+			top: 'calc(50% - 130px)',
+			left: 'calc(50% - 130px)',
 			zIndex: 99,
 		};
 

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -862,14 +862,11 @@ const GameChangerDetailsPage = (props) => {
 										height={670}
 										graphData={graph}
 										runningSearchProp={runningQuery}
-										notificationCountProp={0}
 										setDocumentsFound={() => {}}
 										setTimeFound={() => {}}
 										cloneData={cloneData}
-										expansionTerms={false}
 										setNumOfEdges={() => {}}
 										dispatch={{}}
-										showSideFilters={false}
 										showBasic={false}
 										searchText={''}
 										hierarchyView={hierarchyView}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
Changes how the location of the node context menu is calculated so that it will always open at the center of the graph canvas. Eliminates the dependency on several props and positioning based on the size of other external components.

![image](https://user-images.githubusercontent.com/85301886/155350141-f6b3311a-c514-49d3-9b4c-49f9a62c935b.png)

## Related Issue/Ticket

<!--- Tickets are not required, but will help in determining what the changes are.-->
<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->
https://jira.di2e.net/browse/UOT-132469

## Testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->
Test on both main graph view and details page, at different zoom levels / resolutions. Context menu should always be centered around the node when the node is clicked.