### PR TITLE
added endpoint for getting doc ingest stats

### DIFF
--- a/backend/node_app/controllers/dataTrackerController.js
+++ b/backend/node_app/controllers/dataTrackerController.js
@@ -275,7 +275,7 @@ class DataTrackerController {
 				'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
 			];
 			docsByMonthRaw.forEach(data => {
-				const month = monthNames[data.dataValues.month.getMonth()];
+				const month = monthNames[data.dataValues.month.getUTCMonth()];
 				docsByMonth.push({[month]: Number(data.dataValues.count)});
 			})
 

--- a/backend/node_app/controllers/dataTrackerController.js
+++ b/backend/node_app/controllers/dataTrackerController.js
@@ -7,6 +7,7 @@ const LOGGER = require('../lib/logger');
 const Sequelize = require('sequelize');
 const constantsFile = require('../config/constants');
 const { Op } = require('sequelize');
+const moment = require('moment');
 
 class DataTrackerController {
 
@@ -269,8 +270,12 @@ class DataTrackerController {
 			})
 			
 			const docsByMonth = [];
+			const monthNames = [
+				'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+				'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+			];
 			docsByMonthRaw.forEach(data => {
-				const month = data.dataValues.month.toLocaleString('default', { month: 'short' });
+				const month = monthNames[data.dataValues.month.getMonth()];
 				docsByMonth.push({[month]: Number(data.dataValues.count)});
 			})
 

--- a/backend/node_app/controllers/dataTrackerController.js
+++ b/backend/node_app/controllers/dataTrackerController.js
@@ -248,7 +248,7 @@ class DataTrackerController {
 			const numDocResp = await this.sequelizeGCOrchestration.query('select count (*) from publications where is_revoked is false;');
 			const numberOfDocuments = Number(numDocResp[0][0].count);
 
-			const yearAgo = new Date()
+			const yearAgo = new Date();
 			yearAgo.setMonth(yearAgo.getMonth() - 11);
 			yearAgo.setDate(1);
 			yearAgo.setHours(0);
@@ -268,16 +268,32 @@ class DataTrackerController {
 				],
 				group: 'month'
 			})
+			docsByMonthRaw.sort((a,b) => {
+				if(a.dataValues.month > b.dataValues.month) return 1;
+				return -1;
+			});
 			
-			const docsByMonth = [];
 			const monthNames = [
 				'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
 				'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
 			];
+
+			const monthsObject = {};
 			docsByMonthRaw.forEach(data => {
-				const month = monthNames[data.dataValues.month.getUTCMonth()];
-				docsByMonth.push({[month]: Number(data.dataValues.count)});
+				monthsObject[monthNames[data.dataValues.month.getUTCMonth()]] = data.dataValues.count;
 			})
+
+			const docsByMonth = [];
+			for(let i = 0; i < 12; i++){
+				let monthIndex = yearAgo.getMonth() + i;
+				if(monthIndex - 12 >= 0) monthIndex -= 12;
+				const month = monthNames[monthIndex];
+				if(monthsObject[month]){ 
+					docsByMonth.push({month, count: Number(monthsObject[month])});
+				}else{
+					docsByMonth.push({month, count: 0})
+				}
+			}
 
 			const docIngestionStats = {
 				docsByMonth,

--- a/backend/node_app/routes/gameChangerRouter.js
+++ b/backend/node_app/routes/gameChangerRouter.js
@@ -60,7 +60,7 @@ router.post('/dataTracker/getTrackedSource', dataTracker.getTrackedSource);
 router.post('/getCrawlerMetadata', dataTracker.getCrawlerMetadata);
 router.post('/getCrawlerSeals', dataTracker.getCrawlerInfoData);
 router.post('/getOrgSeals', dataTracker.getOrgSealData);
-router.post('/getDocIngestionStats', dataTracker.getDocIngestionStats);
+router.get('/getDocIngestionStats', dataTracker.getDocIngestionStats);
 
 router.get('/admin/getAdminData', admin.getGCAdminData);
 router.post('/admin/storeAdminData', admin.storeGCAdminData);

--- a/backend/node_app/routes/gameChangerRouter.js
+++ b/backend/node_app/routes/gameChangerRouter.js
@@ -60,6 +60,7 @@ router.post('/dataTracker/getTrackedSource', dataTracker.getTrackedSource);
 router.post('/getCrawlerMetadata', dataTracker.getCrawlerMetadata);
 router.post('/getCrawlerSeals', dataTracker.getCrawlerInfoData);
 router.post('/getOrgSeals', dataTracker.getOrgSealData);
+router.post('/getDocIngestionStats', dataTracker.getDocIngestionStats);
 
 router.get('/admin/getAdminData', admin.getGCAdminData);
 router.post('/admin/storeAdminData', admin.storeGCAdminData);

--- a/backend/security_scan/route_check/whitelist.list
+++ b/backend/security_scan/route_check/whitelist.list
@@ -83,6 +83,7 @@
 .* /api/gamechanger/sendFrontendError .*
 .*/api/gamechanger/getCrawlerSeals .*
 .*/api/gamechanger/getOrgSeals .*
+.* /api/gamechanger/getDocIngestionStats .*
 .*/api/gamechanger/getOrgImageOverrideURLs .*
 .*/api/gamechanger/saveOrgImageOverrideURL .*
 .* /api/gamechanger/aboutGC/getFAQ .*

--- a/backend/test/controllers/dataTrackerController.test.js
+++ b/backend/test/controllers/dataTrackerController.test.js
@@ -315,11 +315,11 @@ describe('DataTrackerController', function () {
 					return Promise.resolve(
 						[
 							{dataValues: {
-								month: new Date(Date.UTC(122, 1)),
+								month: new Date(Date.UTC(2022, 0)),
 								count: '17598'
 							}}, 
 							{dataValues: {
-								month: new Date(Date.UTC(122, 2)),
+								month: new Date(Date.UTC(2022, 1)),
 								count: '10888'
 							}}
 						]

--- a/backend/test/controllers/dataTrackerController.test.js
+++ b/backend/test/controllers/dataTrackerController.test.js
@@ -292,7 +292,7 @@ describe('DataTrackerController', function () {
 
 	describe('#getDocIngestionStats', () => {
 		it('should get doc ingestion stats', async (done) => {	
-			const crawlers = ['crawler1', 'crawler2', 'crawler3']
+			const crawlers = ['crawler1', 'crawler2', 'crawler3'];
 
 			const crawlerInfo = {
 				count() {
@@ -309,17 +309,19 @@ describe('DataTrackerController', function () {
 					);
 				}
 			};
+			const jan = new Date(Date.UTC(2022, 0));
+			const feb = new Date(Date.UTC(2022, 1));
 
 			const documentCorpus = {
 				findAll() {
 					return Promise.resolve(
 						[
 							{dataValues: {
-								month: new Date(Date.UTC(2022, 0)),
+								month: jan,
 								count: '17598'
 							}}, 
 							{dataValues: {
-								month: new Date(Date.UTC(2022, 1)),
+								month: feb,
 								count: '10888'
 							}}
 						]
@@ -333,6 +335,11 @@ describe('DataTrackerController', function () {
 				sequelizeGCOrchestration,
 				documentCorpus
 			};
+
+			const mockDate = new Date('2022-03-08T15:16:45.036Z');
+			jest
+				.spyOn(global, 'Date')
+				.mockImplementationOnce(() => mockDate);
 
 			const target = new DataTrackerController(opts);
 
@@ -356,7 +363,7 @@ describe('DataTrackerController', function () {
 			await target.getDocIngestionStats(req, res);
 
 			const expected = {
-				docsByMonth: [{Jan: 17598}, {Feb: 10888}],
+				docsByMonth: [{count: 0, month: 'Apr'}, {count: 0, month: 'May'}, {count: 0, month: 'Jun'}, {count: 0, month: 'Jul'}, {count: 0, month: 'Aug'}, {count: 0, month: 'Sep'}, {count: 0, month: 'Oct'}, {count: 0, month: 'Nov'}, {count: 0, month: 'Dec'}, {count: 17598, month: 'Jan'}, {count: 10888, month: 'Feb'}, {count: 0, month: 'Mar'}],
 				numberOfSources: 3,    
 				numberOfDocuments: 111263
 			};

--- a/backend/test/controllers/dataTrackerController.test.js
+++ b/backend/test/controllers/dataTrackerController.test.js
@@ -315,8 +315,12 @@ describe('DataTrackerController', function () {
 					return Promise.resolve(
 						[
 							{dataValues: {
-								month: new Date(Date.UTC(122, 2)),
+								month: new Date(Date.UTC(122, 1)),
 								count: '17598'
+							}}, 
+							{dataValues: {
+								month: new Date(Date.UTC(122, 2)),
+								count: '10888'
 							}}
 						]
 					);
@@ -352,7 +356,7 @@ describe('DataTrackerController', function () {
 			await target.getDocIngestionStats(req, res);
 
 			const expected = {
-				docsByMonth: [{Feb: 17598}],
+				docsByMonth: [{Jan: 17598}, {Feb: 10888}],
 				numberOfSources: 3,    
 				numberOfDocuments: 111263
 			};

--- a/backend/test/controllers/dataTrackerController.test.js
+++ b/backend/test/controllers/dataTrackerController.test.js
@@ -289,4 +289,76 @@ describe('DataTrackerController', function () {
 			done();
 		});
 	});
+
+	describe('#getDocIngestionStats', () => {
+		it('should get doc ingestion stats', async (done) => {	
+			const crawlers = ['crawler1', 'crawler2', 'crawler3']
+
+			const crawlerInfo = {
+				count() {
+					return Promise.resolve(
+						crawlers.length
+					);
+				}
+			};
+
+			const sequelizeGCOrchestration = {
+				query() {
+					return Promise.resolve(
+						[[{count: '111263'}]]
+					);
+				}
+			};
+
+			const documentCorpus = {
+				findAll() {
+					return Promise.resolve(
+						[
+							{dataValues: {
+								month: new Date(Date.UTC(122, 2)),
+								count: '17598'
+							}}
+						]
+					);
+				}
+			};
+
+			const opts = {
+				...constructorOptionsMock,
+				crawlerInfo,
+				sequelizeGCOrchestration,
+				documentCorpus
+			};
+
+			const target = new DataTrackerController(opts);
+
+			const req = {
+				...reqMock,
+				body: {}
+			};
+
+			let resData;
+			const res = {
+				status(code) {
+					resCode = code;
+					return this;
+				},
+				send(data) {
+					resData = data;
+					return data;
+				}
+			};
+
+			await target.getDocIngestionStats(req, res);
+
+			const expected = {
+				docsByMonth: [{Feb: 17598}],
+				numberOfSources: 3,    
+				numberOfDocuments: 111263
+			};
+			assert.deepStrictEqual(resData, expected);
+
+			done();
+		});
+	});
 });

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -28,6 +28,7 @@ const endpoints = {
 	gcCloneDataPOST: '/api/gameChanger/modular/admin/storeCloneMeta',
 	gcCloneDataDeletePOST: '/api/gameChanger/modular/admin/deleteCloneMeta',
 	gcDataTrackerDataPOST: '/api/gameChanger/dataTracker/getTrackedData',
+	getDocIngestionStats: '/api/gameChanger/getDocIngestionStats',
 	gcBrowsingLibraryPOST: '/api/gameChanger/dataTracker/getBrowsingLibrary',
 	gcAdminDataGET: '/api/gameChanger/admin/getAdminData',
 	gcAdminDataPOST: '/api/gameChanger/admin/storeAdminData',
@@ -430,6 +431,11 @@ export default class GameChangerAPI {
 
 	getDataTrackerData = async (options) => {
 		const url = endpoints.gcDataTrackerDataPOST;
+		return axiosPOST(this.axios, url, options);
+	};
+
+	getDocIngestionStats = async (options) => {
+		const url = endpoints.getDocIngestionStats;
 		return axiosPOST(this.axios, url, options);
 	};
 

--- a/frontend/src/components/api/gameChanger-service-api.js
+++ b/frontend/src/components/api/gameChanger-service-api.js
@@ -434,9 +434,9 @@ export default class GameChangerAPI {
 		return axiosPOST(this.axios, url, options);
 	};
 
-	getDocIngestionStats = async (options) => {
+	getDocIngestionStats = async () => {
 		const url = endpoints.getDocIngestionStats;
-		return axiosPOST(this.axios, url, options);
+		return axiosGET(this.axios, url);
 	};
 
 	getBrowsingLibrary = async (options) => {


### PR DESCRIPTION
## Description

Adds an end point for getting document ingestion stats. Will be used for a graph and data display on the DST.

## !vibez

Almost done with these DST updates, aaaah yeah. 

## Related Issue/Ticket
Main Ticket: [UOT-130401](https://jira.di2e.net/browse/UOT-130401)
Related Ticket: [UOT-130405](https://jira.di2e.net/browse/UOT-130405)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

The new endpoint is '/api/gameChanger/getDocIngestionStats'. Should get results like:
```
 {
	docsByMonth: [{Feb: 17598}],
	numberOfSources: 3,    
	numberOfDocuments: 111263
}
```
Will need to point to RDS. Some of the data and tables won't exist on your local

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [x] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
