### PR TITLE
add contract search section, include separate paginations

### DIFF
--- a/backend/node_app/controllers/modularGameChangerController.js
+++ b/backend/node_app/controllers/modularGameChangerController.js
@@ -163,12 +163,11 @@ class ModularGameChangerController {
 
 	async search(req, res) {
 		const userId = req.get('SSL_CLIENT_S_DN_CN');
-		const { cloneName, searchText, limit = 18, options } = req.body;
+		const { cloneName, searchText, limit = 18, options, storeHistory = true } = req.body;
 		let { offset = 0 } = req.body;
 		try {
 			// NOTE: if this code changes then this will likely necessitate changes to `favoritesController.checkLeastRecentFavoritedSearch`
 			const handler = this.handler_factory.createHandler('search', cloneName);
-			const storeHistory = true;
 			if (offset === null) offset = 0;
 			const results = await handler.search(searchText, offset, limit, options, cloneName, req.permissions, userId, storeHistory, req.session);
 			const error = handler.getError();

--- a/backend/node_app/modules/eda/edaSearchHandler.js
+++ b/backend/node_app/modules/eda/edaSearchHandler.js
@@ -144,7 +144,7 @@ class EdaSearchHandler extends SearchHandler {
 	
 			const { esClientName, esIndex } = clientObj;
 			let esQuery = '';
-			if (permissions.includes('View EDA') || permissions.includes('Webapp Super Admin')) {
+			if (permissions.includes('View EDA') || permissions.includes('Webapp Super Admin') || permissions.includes('eda Admin')) {
 				const {extSearchFields = [], extRetrieveFields = [] } = this.constants.EDA_ELASTIC_SEARCH_OPTS;
 				body.extSearchFields = extSearchFields.map((field) => field.toLowerCase());
 				body.extStoredFields = extRetrieveFields.map((field) => field.toLowerCase());

--- a/backend/node_app/modules/jbook/jbookSearchHandler.js
+++ b/backend/node_app/modules/jbook/jbookSearchHandler.js
@@ -473,8 +473,6 @@ class JBookSearchHandler extends SearchHandler {
 
 						let titles = accomps[0].replace(/[\"]\s*/g, '').split('; ');
 
-						console.log(titles);
-
 						doc.accomplishments = titles;
 
 					} catch(e) {

--- a/frontend/src/components/cards/GCCard.js
+++ b/frontend/src/components/cards/GCCard.js
@@ -332,6 +332,7 @@ function GCCard(props) {
 		closeGraphCard = () => {},
 		collection = [],
 		detailPage = false,
+		card_module = null,
 	} = props;
 
 	const cardType = item.type;
@@ -399,7 +400,8 @@ function GCCard(props) {
 	useEffect(() => {
 		// Create the factory
 		if (cardType && !loaded) {
-			const factory = new CardFactory(state.cloneData.card_module);
+			let module_name = card_module ?? state.cloneData.card_module;
+			const factory = new CardFactory(module_name);
 			const handler = factory.createHandler();
 			setCardHandler(handler[cardType]);
 			setCompareIndex(0);

--- a/frontend/src/components/modules/jbook/jbookContext.js
+++ b/frontend/src/components/modules/jbook/jbookContext.js
@@ -232,6 +232,25 @@ const initState = {
 		show_feedback: false,
 		config: { esIndex: 'gc_budgetsearch' }
 	},
+	edaCloneData: {
+		clone_name: 'eda',
+		search_module: 'eda/edaSearchHandler',
+		export_module: 'eda/edaExportHandler',
+		title_bar_module: 'eda/edaTitleBarHandler',
+		navigation_module: 'eda/edaNavigationHandler',
+		card_module: 'eda/edaCardHandler',
+		main_view_module: 'eda/edaMainViewHandler',
+		search_bar_module: 'eda/edaSearchBarHandler',
+		display_name: 'ContractSearch',
+		is_live: true,
+		url: 'contractsearch',
+		permissions_required: true,
+		clone_to_sipr: false,
+		show_tutorial: false,
+		show_graph: false,
+		show_crowd_source: false,
+		show_feedback: true
+	},
 
 	loading: true,
 	profileLoading: false,
@@ -279,8 +298,16 @@ const initState = {
 	listView: false,
 
 	// contract totals
-	contractTotals: {}
+	contractTotals: {},
 
+	paginationSearch: false,
+
+	// v --- EDA VARIABLES --- v
+	edaSearchResults: [],
+	edaCount: 0,
+	edaLoading: false,
+	edaResultsPage: 1,
+	edaPaginationSearch: false,
 }
 
 const init = (initialState) => {

--- a/frontend/src/components/modules/jbook/jbookMainViewHandler2.js
+++ b/frontend/src/components/modules/jbook/jbookMainViewHandler2.js
@@ -41,11 +41,11 @@ export const GC_COLORS = {
 	secondary: '#E9691D'
 };
 
-const getSearchResults = (searchResultData, state, dispatch) => {
+const getSearchResults = (searchResultData, state, dispatch, module = null) => {
 	return _.map(searchResultData, (item, idx) => {
 		item.type = 'document';
 		return (
-			<Card key={idx} item={item} idx={idx} state={state} dispatch={dispatch} />
+			<Card key={idx} item={item} idx={idx} state={state} dispatch={dispatch} card_module={module}/>
 		);
 	});
 };
@@ -162,7 +162,12 @@ const jbookMainViewHandler = {
 			showSideFilters,
 			rawSearchResults,
 			mainTabSelected,
-			runningSearch
+			runningSearch,
+			edaSearchResults,
+			edaLoading,
+			edaCloneData,
+			edaResultsPage,
+			edaCount
 		} = state;
 
 		let sideScroll = {
@@ -243,6 +248,7 @@ const jbookMainViewHandler = {
 																<Typography variant="h6" display="inline" title="jbookSearch">JBOOK SEARCH ({count})</Typography>
 
 															</Tab>
+															{(Permissions.permissionValidator(`${edaCloneData.clone_name} Admin`, true) || Permissions.permissionValidator(`View ${edaCloneData.clone_name}`, true)) && (
 															<Tab style={{
 																...styles.tabStyle,
 																...(mainTabSelected === 1 ? styles.tabSelectedStyle : {}),
@@ -251,6 +257,7 @@ const jbookMainViewHandler = {
 															>
 																<Typography variant="h6" display="inline" title="contractSearch">CONTRACT SEARCH</Typography>
 															</Tab>
+															)}
 														</div>
 													</TabList>
 
@@ -274,8 +281,9 @@ const jbookMainViewHandler = {
 																				totalItemsCount={count}
 																				pageRangeDisplayed={8}
 																				onChange={page => {
+																					console.log('jbook pagination search')
 																					trackEvent(getTrackingNameForFactory(state.cloneData.clone_name), 'PaginationChanged', 'page', page);
-																					setState(dispatch, { resultsPage: page, runSearch: true, loading: true });
+																					setState(dispatch, { resultsPage: page, runSearch: true, loading: true, paginationSearch: true });
 																					scrollToContentTop();
 																				}}
 																			/>
@@ -285,7 +293,38 @@ const jbookMainViewHandler = {
 															}
 														</TabPanel>
 														<TabPanel>
-															{'contract search'}
+															{(Permissions.permissionValidator(`${edaCloneData.clone_name} Admin`, true) || Permissions.permissionValidator(`View ${edaCloneData.clone_name}`, true)) && (
+															<>
+																{
+																	edaLoading && (
+																		<div style={{ margin: '0 auto' }}>
+																			<LoadingIndicator customColor={GC_COLORS.primary} />
+																		</div>
+																	)
+																}
+																{
+																	!edaLoading && (
+																		<div className="row" style={{ padding: 5 }}>
+																			{getSearchResults(edaSearchResults ? edaSearchResults : [], state, dispatch, edaCloneData.card_module)}
+																			<div className="jbookPagination col-xs-12 text-center">
+																				<Pagination
+																					activePage={edaResultsPage}
+																					itemsCountPerPage={18}
+																					totalItemsCount={edaCount}
+																					pageRangeDisplayed={8}
+																					onChange={page => {
+																						trackEvent(getTrackingNameForFactory(edaCloneData.clone_name), 'PaginationChanged', 'page', page);
+																						setState(dispatch, { edaResultsPage: page, runSearch: true, edaPaginationSearch: true });
+																						scrollToContentTop();
+																					}}
+																				/>
+																			</div>
+																		</div>
+																	)
+																}
+															</>
+															)
+															}					
 														</TabPanel>
 													</div>
 												</div>

--- a/frontend/src/components/modules/jbook/jbookMainViewHelper.js
+++ b/frontend/src/components/modules/jbook/jbookMainViewHelper.js
@@ -102,24 +102,10 @@ export const setJBookSetting = (field, value, state, dispatch, filteredList = fa
 }
 
 export const handleTabClicked = (dispatch, state, tab) => {
-	const { tabs } = state;
-	const isSummary = tabs[tab] === 'summary';
 
-	const paramsIndex = window.location.hash.indexOf('?');
-	let params = '';
-	if (paramsIndex !== -1) {
-		params = window.location.hash.substring(paramsIndex);
-	}
-	else {
-		params = state.queryParams;
-	}
 
 	setState(dispatch, { mainTabSelected: tab });
-	if (isSummary) {
-		setState(dispatch, { queryParams: params });
-	}
 
-	window.history.replaceState(undefined, undefined, `#/jbook/${tabs[tab]}${isSummary ? '' : params}`);
 }
 
 export const scrollListViewTop = () => {

--- a/frontend/src/components/modules/jbook/jbookSearchHandler.js
+++ b/frontend/src/components/modules/jbook/jbookSearchHandler.js
@@ -124,112 +124,186 @@ const JBookSearchHandler = {
 		const {
 			searchText = '',
 			resultsPage,
-			urlSearch
+			urlSearch,
+			paginationSearch,
+			edaPaginationSearch
 		} = state;
 
-		scrollListViewTop();
-
-		if (!urlSearch) {
-			this.setSearchURL(state);
+		
+		if (edaPaginationSearch) {
+			this.handleEDASearch(state, dispatch);
 		}
+		else {
 
-		this.updateRecentSearches(searchText);
-
-		setState(dispatch,
-			{
-				runSearch: false,
-				budgetTypeDropdown: false,
-				serviceAgencyDropdown: false,
-				serviceReviewStatusDropdown: false,
-				reviewStatusDropdown: false,
-				budgetYearDropdown: false,
-				primaryReviewerDropdown: false,
-				serviceReviewerDropdown: false,
-				primaryClassLabelDropdown: false,
-				sourceTagDropdown: false,
-				hasKeywordsDropdown: false,
-				noResultsMessage: null,
-				count: 0,
-				timeFound: 0.0,
-				iframePreviewLink: null,
-				runningSearch: true,
-				urlSearch: false,
-				initial: false,
-				expansionDict: {},
-			});
-
-		try {
-			const t0 = new Date().getTime();
-			const results = await this.performQuery(state, searchText, resultsPage, dispatch);
-			const { contractTotals } = await this.getContractTotals(state, dispatch);
-			const t1 = new Date().getTime();
-
-			//console.log(results);
-
-			if (results === null || (!results.docs || results.docs.length <= 0)) {
-				setState(dispatch, {
-					prevSearchText: null,
-					loading: false,
-					searchResultsCount: 0,
-					noResultsMessage: NO_RESULTS_MESSAGE,
-					runningSearch: false,
-					loadingTinyUrl: false,
-					rawSearchResults: [],
-					hasExpansionTerms: false,
+			if (!urlSearch) {
+				this.setSearchURL(state);
+			}
+	
+			this.updateRecentSearches(searchText);
+	
+			setState(dispatch,
+				{
+					runSearch: false,
+					budgetTypeDropdown: false,
+					serviceAgencyDropdown: false,
+					serviceReviewStatusDropdown: false,
+					reviewStatusDropdown: false,
+					budgetYearDropdown: false,
+					primaryReviewerDropdown: false,
+					serviceReviewerDropdown: false,
+					primaryClassLabelDropdown: false,
+					sourceTagDropdown: false,
+					hasKeywordsDropdown: false,
+					noResultsMessage: null,
+					count: 0,
+					timeFound: 0.0,
+					iframePreviewLink: null,
+					runningSearch: true,
+					urlSearch: false,
+					initial: false,
+					expansionDict: {},
 				});
-			} else {
-				let { docs, totalCount, query, expansionDict, } = results;
-
-				let hasExpansionTerms = false;
-				if (expansionDict) {
-					Object.keys(expansionDict).forEach((key) => {
-						if (expansionDict[key].length > 0) hasExpansionTerms = true;
+	
+			try {
+				const t0 = new Date().getTime();
+	
+				// run these simultaneously
+				if (!paginationSearch) {
+					this.handleEDASearch(state, dispatch);
+				}
+	
+				const results = await this.performQuery(state, searchText, resultsPage, dispatch);
+				const { contractTotals } = await this.getContractTotals(state, dispatch);
+				const t1 = new Date().getTime();
+	
+	
+				if (results === null || (!results.docs || results.docs.length <= 0)) {
+					setState(dispatch, {
+						prevSearchText: null,
+						loading: false,
+						searchResultsCount: 0,
+						noResultsMessage: NO_RESULTS_MESSAGE,
+						runningSearch: false,
+						loadingTinyUrl: false,
+						rawSearchResults: [],
+						hasExpansionTerms: false,
+						paginationSearch: false,
+					});
+				} else {
+					let { docs, totalCount, query, expansionDict, } = results;
+	
+					let hasExpansionTerms = false;
+					if (expansionDict) {
+						Object.keys(expansionDict).forEach((key) => {
+							if (expansionDict[key].length > 0) hasExpansionTerms = true;
+						});
+					}
+	
+					setState(dispatch, {
+						timeFound: ((t1 - t0) / 1000).toFixed(2),
+						activeCategoryTab: 'jbook',
+						prevSearchText: searchText,
+						loading: false,
+						loadingTinyUrl: false,
+						count: totalCount,
+						query: query,
+						rawSearchResults: docs,
+						hideTabs: false,
+						resetSettingsSwitch: false,
+						runningSearch: false,
+						contractTotals: contractTotals,
+						expansionDict,
+						hasExpansionTerms,
+						paginationSearch: false,
 					});
 				}
-
+	
+				if (resultsPage < 2) {
+					trackSearch(
+						searchText,
+						`${getTrackingNameForFactory('jbook')}`,
+						results.totalCount,
+						false
+					);
+				}
+				// this.setSearchURL({...state, searchText, resultsPage, tabName});
+			} catch (e) {
+				console.log(e);
 				setState(dispatch, {
-					timeFound: ((t1 - t0) / 1000).toFixed(2),
-					activeCategoryTab: 'jbook',
-					prevSearchText: searchText,
+					prevSearchText: null,
+					unauthorizedError: true,
 					loading: false,
-					loadingTinyUrl: false,
-					count: totalCount,
-					query: query,
-					rawSearchResults: docs,
-					hideTabs: false,
-					resetSettingsSwitch: false,
+					autocompleteItems: [],
+					searchResultsCount: 0,
 					runningSearch: false,
-					contractTotals: contractTotals,
-					expansionDict,
-					hasExpansionTerms
+					loadingTinyUrl: false,
+					hasExpansionTerms: false,
+					paginationSearch: false,
 				});
 			}
-
-			if (resultsPage < 2) {
-				trackSearch(
-					searchText,
-					`${getTrackingNameForFactory('jbook')}`,
-					results.totalCount,
-					false
-				);
-			}
-			// this.setSearchURL({...state, searchText, resultsPage, tabName});
-		} catch (e) {
-			console.log(e);
-			setState(dispatch, {
-				prevSearchText: null,
-				unauthorizedError: true,
-				loading: false,
-				autocompleteItems: [],
-				searchResultsCount: 0,
-				runningSearch: false,
-				loadingTinyUrl: false,
-				hasExpansionTerms: false
-			});
+	
+			const index = 'gamechanger';
+			getAndSetDidYouMean(index, searchText, dispatch);
 		}
 
-		const index = 'gamechanger';
-		getAndSetDidYouMean(index, searchText, dispatch);
+		
+	},
+
+	async handleEDASearch(state, dispatch) {
+		const {
+			searchText = '',
+			edaResultsPage,
+			edaCloneData
+		} = state;
+
+		// let searchResults = [];
+		setState(dispatch, {
+			edaCount: 0,
+			edaSearchResults: [],
+			edaLoading: true,
+			edaPaginationSearch: false,
+			runSearch: false
+		});
+
+		const offset = (edaResultsPage - 1) * RESULTS_PER_PAGE;
+		const charsPadding = 90;
+
+		try {
+			// run EDA Search
+			// const t0 = new Date().getTime();
+			const results = await gamechangerAPI.modularSearch({
+				cloneName: edaCloneData.clone_name, 
+				searchText,
+				offset,
+				storeHistory: false,
+				options: {
+					charsPadding
+				}
+			});
+
+			// const t1 = new Date().getTime();
+
+			if (_.isObject(results.data)) {
+				let { docs, totalCount} = results.data;
+
+				// set EDA search results
+				if (docs && Array.isArray(docs)) {
+					setState(dispatch, {
+						edaLoading: false,
+						edaCount: totalCount,
+						edaSearchResults: docs
+					});
+				}
+			}
+			else {
+				setState(dispatch, {
+					edaLoading: false,
+				})
+			}
+		} catch (e) {
+			console.log('Error running EDA search in JBOOK');
+			console.log(e);
+		}
 	},
 
 	parseSearchURL(defaultState, url) {


### PR DESCRIPTION
## Description

- make the contract search tab under permissions ('View eda' or 'eda Admin' only)
- added an additional search function to jbook search just for grabbing EDA results (search text only)
- run that search alongside jbook search and show the card results in contract search tab
- split the paginations between the 2 tabs

## !vibez

The idea of the clones overlapping like this where I added EDA search to Jbook search handler seems iffy, but necessary for the ask

## Related Issue/Ticket

<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->

https://jira.di2e.net/browse/UOT-134501

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, frontend pages, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->

Must have the "View eda" or "eda Admin" permission to view the contract search tab on jbook.

Run a search on jbook, see if the eda results show up on contract search tab. Click pagination on each and make sure the other tab still works/are separate.

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [x] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
