### PR TITLE
Task/uot 130405

### DIFF
--- a/backend/test/controllers/dataTrackerController.test.js
+++ b/backend/test/controllers/dataTrackerController.test.js
@@ -234,6 +234,104 @@ describe('DataTrackerController', function () {
 			}
 
 		});
+
+		it('should get crawler data for data status tracker table', async (done) => {
+			const apiStatusResMock = [{crawler_name: 'test', status: 'Ingest Complete', datetime: new Date('2021-02-19T21:12:56.119Z')}, {crawler_name: 'test2', status: 'In Progress', datetime: new Date('2021-02-20T00:57:27.774Z')}];
+			const apiInfoResMock = [{dataValues: {crawler: 'test', url_origin: 'test', data_source_s: 'test', source_title: 'test'}}, {dataValues: {crawler: 'test2', url_origin: 'test2', data_source_s: 'test2', source_title: 'test2'}}];
+			const crawlerStatus = {
+				findAll() {
+					return Promise.resolve(apiStatusResMock);
+				}
+			};
+			const crawlerInfo = {
+				findAll() {
+					return Promise.resolve(apiInfoResMock);
+				}
+			};
+			const opts = {
+				...constructorOptionsMock,
+				crawlerStatus,
+				crawlerInfo
+			};
+			const target = new DataTrackerController(opts);
+
+			const req = {
+				...reqMock,
+				body: {limit: 10, offset: 0, order: [], where: [], option: 'status'}
+			};
+
+			let resMsg;
+			let resCode;
+			const res = {
+				status(code) {
+					resCode = code;
+					return this;
+				},
+				send(msg) {
+					resMsg = msg;
+				}
+			};
+
+			try {
+				const expected = {totalCount: 2, docs: [{crawler_name: 'test', data_source_s: 'test', source_title: 'test', url_origin: 'test', status: 'Ingest Complete', datetime: new Date('2021-02-19T21:12:56.119Z')}, {crawler_name: 'test2', data_source_s: 'test2', source_title: 'test2', url_origin: 'test2', status: 'In Progress', datetime: new Date('2021-02-20T00:57:27.774Z')}]};
+				await target.getCrawlerMetadata(req, res);
+				assert.strictEqual(resCode, 200);
+				assert.deepStrictEqual(resMsg, expected);
+				done();
+			} catch (e) {
+				assert.fail(e);
+			}
+
+		});
+
+		it('should get crawler data sorted by name for data status tracker table', async (done) => {
+			const apiStatusResMock = [{crawler_name: 'cTest', status: 'Ingest Complete', datetime: new Date('2021-02-19T21:12:56.119Z')}, {crawler_name: 'aTest2', status: 'In Progress', datetime: new Date('2021-02-20T00:57:27.774Z')}];
+			const apiInfoResMock = [{dataValues: {crawler: 'cTest', url_origin: 'test', data_source_s: 'cTest', source_title: 'test'}}, {dataValues: {crawler: 'aTest2', url_origin: 'test2', data_source_s: 'aTest2', source_title: 'test2'}}];
+			const crawlerStatus = {
+				findAll() {
+					return Promise.resolve(apiStatusResMock);
+				}
+			};
+			const crawlerInfo = {
+				findAll() {
+					return Promise.resolve(apiInfoResMock);
+				}
+			};
+			const opts = {
+				...constructorOptionsMock,
+				crawlerStatus,
+				crawlerInfo
+			};
+			const target = new DataTrackerController(opts);
+
+			const req = {
+				...reqMock,
+				body: {limit: 10, offset: 0, order: [['crawler_name', 'ASC']], where: [], option: 'status'}
+			};
+
+			let resMsg;
+			let resCode;
+			const res = {
+				status(code) {
+					resCode = code;
+					return this;
+				},
+				send(msg) {
+					resMsg = msg;
+				}
+			};
+
+			try {
+				const expected = {totalCount: 2, docs: [{crawler_name: 'aTest2', data_source_s: 'aTest2', source_title: 'test2', url_origin: 'test2', status: 'In Progress', datetime: new Date('2021-02-20T00:57:27.774Z')}, {crawler_name: 'cTest', data_source_s: 'cTest', source_title: 'test', url_origin: 'test', status: 'Ingest Complete', datetime: new Date('2021-02-19T21:12:56.119Z')}]};
+				await target.getCrawlerMetadata(req, res);
+				assert.strictEqual(resCode, 200);
+				assert.deepStrictEqual(resMsg, expected);
+				done();
+			} catch (e) {
+				assert.fail(e);
+			}
+
+		});
 	});
 
 	describe('#getOrgSealData', () => {

--- a/backend/test/controllers/dataTrackerController.test.js
+++ b/backend/test/controllers/dataTrackerController.test.js
@@ -17,8 +17,8 @@ describe('DataTrackerController', function () {
 			let passedCountParams = null;
 			let passedFindAllParams = null;
 			const documentCorpus = {
-				count: async (countParams) => { passedCountParams = countParams; return 2; },
-				findAll: async (findAllParams) => { passedFindAllParams = findAllParams; return fakeDocumentCorpusResponse; }
+				count: async (countParams) => { passedCountParams = countParams; return 2 },
+				findAll: async (findAllParams) => { passedFindAllParams = findAllParams; return fakeDocumentCorpusResponse }
 			};
 
 			const opts = {
@@ -80,8 +80,8 @@ describe('DataTrackerController', function () {
 			let passedCountParams = null;
 			let passedFindAllParams = null;
 			const documentCorpus = {
-				count: async (countParams) => { passedCountParams = countParams; return 2; },
-				findAll: async (findAllParams) => { passedFindAllParams = findAllParams; return fakeDocumentCorpusResponse; }
+				count: async (countParams) => { passedCountParams = countParams; return 2 },
+				findAll: async (findAllParams) => { passedFindAllParams = findAllParams; return fakeDocumentCorpusResponse }
 			};
 
 			const opts = {
@@ -145,8 +145,8 @@ describe('DataTrackerController', function () {
 			let passedCountParams = null;
 			let passedFindAllParams = null;
 			const documentCorpus = {
-				count: async (countParams) => { passedCountParams = countParams; throw 'My fake error'; },
-				findAll: async (findAllParams) => { passedFindAllParams = findAllParams; return fakeDocumentCorpusResponse; }
+				count: async (countParams) => { passedCountParams = countParams; throw 'My fake error' },
+				findAll: async (findAllParams) => { passedFindAllParams = findAllParams; return fakeDocumentCorpusResponse }
 			};
 
 			const opts = {

--- a/frontend/src/components/dataTracker/GCDataStatusTracker.js
+++ b/frontend/src/components/dataTracker/GCDataStatusTracker.js
@@ -14,6 +14,7 @@ import GameChangerAPI from '../api/gameChanger-service-api';
 import { MemoizedNodeCluster2D } from '../graph/GraphNodeCluster2D';
 import { getTrackingNameForFactory } from '../../utils/gamechangerUtils';
 import { trackEvent } from '../telemetry/Matomo';
+import IngestStats from './IngestStats';
 
 const GoalIcon = styled.div`
 	height: 20px;
@@ -25,6 +26,7 @@ const TableRow = styled.div`
 	height: 100%;
 	display: flex;
 	align-items: center;
+	justify-content: center;
 `;
 const CenterRow = styled.div`
 	display: flex;
@@ -607,7 +609,15 @@ const GCDataStatusTracker = (props) => {
 			{
 				Header: 'Source',
 				accessor: 'crawler_name',
-				Cell: (row) => <TableRow>{matchCrawlerName(row.value)}</TableRow>,
+				Cell: (row) => 
+					<TableRow>
+						<a 
+							href={row.original.url_origin ? row.original.url_origin : '#'} 
+							target='_blank' 
+							rel="noreferrer">
+							{matchCrawlerName(row.value)}
+						</a>
+					</TableRow>,
 				style: { 'whiteSpace': 'unset' },
 			},
 			{
@@ -724,20 +734,23 @@ const GCDataStatusTracker = (props) => {
 						</div>
 					</div>
 				</SectionHeader>
-				<TableStyle>
-					<ReactTable
-						data={crawlerTableData}
-						columns={crawlerColumns}
-						style={{whiteSpace: 'unset', margin: '0 0 20px 0', height: 'auto' }}
-						pageSize={PAGE_SIZE}
-						showPageSizeOptions={false}
-						filterable={false}
-						loading={loading}
-						manual={true}
-						pages={numPages}
-						onFetchData={handleFetchCrawlerData}
-					/>
-				</TableStyle>
+				<div style={{display: 'flex'}}>
+					<TableStyle style={{width: '75%'}}>
+						<ReactTable
+							data={crawlerTableData}
+							columns={crawlerColumns}
+							style={{whiteSpace: 'unset', margin: '0 0 20px 0', height: 'auto' }}
+							pageSize={PAGE_SIZE}
+							showPageSizeOptions={false}
+							filterable={false}
+							loading={loading}
+							manual={true}
+							pages={numPages}
+							onFetchData={handleFetchCrawlerData}
+						/>
+					</TableStyle>
+					<IngestStats style={{width: '25%'}}/>
+				</div>
 			</>
 		);
 	};

--- a/frontend/src/components/dataTracker/GCDataStatusTracker.js
+++ b/frontend/src/components/dataTracker/GCDataStatusTracker.js
@@ -609,7 +609,7 @@ const GCDataStatusTracker = (props) => {
 					return row.original.url_origin ?
 						<TableRow>
 							<a 
-								href={row.original.url_origin ? row.original.url_origin : '#'} 
+								href={row.original.url_origin} 
 								target='_blank' 
 								rel="noreferrer">
 								{getCrawlerName(row.original)}

--- a/frontend/src/components/dataTracker/GCDataStatusTracker.js
+++ b/frontend/src/components/dataTracker/GCDataStatusTracker.js
@@ -110,7 +110,7 @@ const TableStyle = styled.div`
 			}
 		}
 	}
-`
+`;
 
 const styles = {
 	legendItem: {
@@ -122,7 +122,7 @@ const styles = {
 		textTransform: 'uppercase',
 		fontWeight: 'bold'
 	}
-}
+};
 
 const gameChangerAPI = new GameChangerAPI();
 
@@ -586,7 +586,7 @@ const GCDataStatusTracker = (props) => {
 				percent = '66%';
 				break;
 			case 'Ingest Complete':
-				percent = '100%'
+				percent = '100%';
 				break;
 			default:
 				percent = '0%';
@@ -599,8 +599,8 @@ const GCDataStatusTracker = (props) => {
 			<div style={{maxWidth: 150, width: '80%', height: 8, background: '#D8D8D8', borderRadius: '24px', position: 'relative'}}>
 				<div style={{width: percent, height: 8, background: '#969696', borderRadius: '24px', position: 'absolute'}}/>
 			</div>
-		</>)
-	}
+		</>);
+	};
 
 	const renderCrawlerData = () => {
 		const crawlerColumns = [

--- a/frontend/src/components/dataTracker/GCDataStatusTracker.js
+++ b/frontend/src/components/dataTracker/GCDataStatusTracker.js
@@ -609,15 +609,21 @@ const GCDataStatusTracker = (props) => {
 			{
 				Header: 'Source',
 				accessor: 'crawler_name',
-				Cell: (row) => 
-					<TableRow>
-						<a 
-							href={row.original.url_origin ? row.original.url_origin : '#'} 
-							target='_blank' 
-							rel="noreferrer">
+				Cell: (row) =>{
+					return row.original.url_origin ?
+						<TableRow>
+							<a 
+								href={row.original.url_origin ? row.original.url_origin : '#'} 
+								target='_blank' 
+								rel="noreferrer">
+								{matchCrawlerName(row.value)}
+							</a>
+						</TableRow>
+						:
+						<TableRow>
 							{matchCrawlerName(row.value)}
-						</a>
-					</TableRow>,
+						</TableRow>;
+				},
 				style: { 'whiteSpace': 'unset' },
 			},
 			{
@@ -682,7 +688,6 @@ const GCDataStatusTracker = (props) => {
 			{
 				Header: 'Last Action',
 				accessor: 'datetime',
-				width: 150,
 				Cell: (row) => {
 					return (
 						<TableRow>
@@ -694,7 +699,6 @@ const GCDataStatusTracker = (props) => {
 			{
 				Header: 'Days Since Last Ingest',
 				accessor: 'datetime',
-				width: 200,
 				Cell: (row) => {
 					return <TableRow>{date_difference(Date.parse(row.value))}</TableRow>;
 				},

--- a/frontend/src/components/dataTracker/IngestStats.js
+++ b/frontend/src/components/dataTracker/IngestStats.js
@@ -1,0 +1,73 @@
+import React, { useEffect, useState } from 'react'
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import GameChangerAPI from '../api/gameChanger-service-api';
+import LoadingIndicator from '@dod-advana/advana-platform-ui/dist/loading/LoadingIndicator';
+import { gcOrange } from '../common/gc-colors';
+import StatPill from './StatPill';
+
+const gameChangerAPI = new GameChangerAPI();
+
+export default function IngestStats() {
+
+	const [ingestData, setIngestData] = useState({});
+
+	useEffect(() => {
+		gameChangerAPI.getDocIngestionStats().then(res => {
+			setIngestData(res.data)
+		});
+	}, [])
+
+	useEffect(() => {
+		console.log('ingestData: ', ingestData)
+	}, [ingestData])
+
+	const getDomain = () => {
+		let highest = 0;
+		if(ingestData.docsByMonth){
+			ingestData.docsByMonth.forEach(data => {
+				if(data.count > highest) {
+					highest = data.count
+				};
+			})
+			const tens = String(highest).length - 1;
+			const domain = Math.ceil(highest/(Math.pow(10, tens))) * Math.pow(10, tens);
+			return domain;
+		}
+		return 10000;
+	}
+
+	return (
+		<div style={{marginLeft: 20, width: '25%'}}>
+			<div style={{background: '#F7F7F7', padding: 20, marginBottom: 20, minHeight: 300 }}>
+				<div style={{font: 'normal normal 600 14px Noto Sans', color: '#666666', marginBottom: 10}}>DOCUMENTS INGESTION BY MONTH</div>
+				<div style={{height: 250}}>
+					<ResponsiveContainer width='100%' height='100%'>
+						{Object.keys(ingestData).length ?
+							<BarChart
+								data={ingestData.docsByMonth}
+								margin={{
+									top: 15,
+									right: 30,
+									left: 20,
+									bottom: 5,
+								}}
+							>
+								<XAxis dataKey='month' />
+								<YAxis allowDataOverflow={true} type="number" domain={[0, getDomain()]} width={35}/>
+								<Tooltip />
+								<Bar dataKey="count" fill={gcOrange} />
+							</BarChart>
+							:
+							<LoadingIndicator customColor={gcOrange} />
+						}
+					</ResponsiveContainer>
+				</div>
+			</div>
+			<div>
+				<div style={{marginBottom: 10, font: 'normal normal 600 14px Noto Sans'}}>DOCUMENTS ANALYTICS</div>
+				<StatPill stat={Number(ingestData.numberOfDocuments).toLocaleString()} descriptor={'NUMBER OF DOCUMENTS INGESTED'}/>
+				<StatPill stat={ingestData.numberOfSources} descriptor={'NUMBER OF DOCUMENT SOURCES'}/>
+			</div>		
+		</div>
+	);
+}

--- a/frontend/src/components/dataTracker/IngestStats.js
+++ b/frontend/src/components/dataTracker/IngestStats.js
@@ -17,10 +17,6 @@ export default function IngestStats() {
 		});
 	}, []);
 
-	useEffect(() => {
-		console.log('ingestData: ', ingestData);
-	}, [ingestData]);
-
 	const getDomain = () => {
 		let highest = 0;
 		if(ingestData.docsByMonth){

--- a/frontend/src/components/dataTracker/IngestStats.js
+++ b/frontend/src/components/dataTracker/IngestStats.js
@@ -1,21 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
-import GameChangerAPI from '../api/gameChanger-service-api';
 import LoadingIndicator from '@dod-advana/advana-platform-ui/dist/loading/LoadingIndicator';
 import { gcOrange } from '../common/gc-colors';
 import StatPill from './StatPill';
 
-const gameChangerAPI = new GameChangerAPI();
-
-export default function IngestStats() {
-
-	const [ingestData, setIngestData] = useState({});
-
-	useEffect(() => {
-		gameChangerAPI.getDocIngestionStats().then(res => {
-			setIngestData(res.data);
-		});
-	}, []);
+export default function IngestStats({ingestData}) {
 
 	const getDomain = () => {
 		let highest = 0;
@@ -61,7 +50,7 @@ export default function IngestStats() {
 			</div>
 			<div>
 				<div style={{marginBottom: 10, font: 'normal normal 600 14px Noto Sans'}}>DOCUMENTS ANALYTICS</div>
-				<StatPill stat={Number(ingestData.numberOfDocuments).toLocaleString()} descriptor={'NUMBER OF DOCUMENTS INGESTED'}/>
+				<StatPill stat={ingestData.numberOfDocuments? Number(ingestData.numberOfDocuments).toLocaleString() : 0} descriptor={'NUMBER OF DOCUMENTS INGESTED'}/>
 				<StatPill stat={ingestData.numberOfSources} descriptor={'NUMBER OF DOCUMENT SOURCES'}/>
 			</div>		
 		</div>

--- a/frontend/src/components/dataTracker/IngestStats.js
+++ b/frontend/src/components/dataTracker/IngestStats.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import GameChangerAPI from '../api/gameChanger-service-api';
 import LoadingIndicator from '@dod-advana/advana-platform-ui/dist/loading/LoadingIndicator';
@@ -13,33 +13,33 @@ export default function IngestStats() {
 
 	useEffect(() => {
 		gameChangerAPI.getDocIngestionStats().then(res => {
-			setIngestData(res.data)
+			setIngestData(res.data);
 		});
-	}, [])
+	}, []);
 
 	useEffect(() => {
-		console.log('ingestData: ', ingestData)
-	}, [ingestData])
+		console.log('ingestData: ', ingestData);
+	}, [ingestData]);
 
 	const getDomain = () => {
 		let highest = 0;
 		if(ingestData.docsByMonth){
 			ingestData.docsByMonth.forEach(data => {
 				if(data.count > highest) {
-					highest = data.count
+					highest = data.count;
 				};
-			})
+			});
 			const tens = String(highest).length - 1;
 			const domain = Math.ceil(highest/(Math.pow(10, tens))) * Math.pow(10, tens);
 			return domain;
 		}
 		return 10000;
-	}
+	};
 
 	return (
 		<div style={{marginLeft: 20, width: '25%'}}>
 			<div style={{background: '#F7F7F7', padding: 20, marginBottom: 20, minHeight: 300 }}>
-				<div style={{font: 'normal normal 600 14px Noto Sans', color: '#666666', marginBottom: 10}}>DOCUMENTS INGESTION BY MONTH</div>
+				<div style={{font: 'normal normal 600 14px Noto Sans', color: '#666666', marginBottom: 10}}>DOCUMENTS INGESTED BY MONTH</div>
 				<div style={{height: 250}}>
 					<ResponsiveContainer width='100%' height='100%'>
 						{Object.keys(ingestData).length ?

--- a/frontend/src/components/dataTracker/StatPill.js
+++ b/frontend/src/components/dataTracker/StatPill.js
@@ -1,5 +1,5 @@
-import React from 'react'
-import { gcOrange } from '../common/gc-colors'
+import React from 'react';
+import { gcOrange } from '../common/gc-colors';
 
 export default function StatPill({ stat, descriptor }) {
 	return (
@@ -7,5 +7,5 @@ export default function StatPill({ stat, descriptor }) {
 			<div style={{color: gcOrange, font: 'normal normal 600 28px/20px Noto Sans', marginBottom: 5}}>{stat}</div>
 			<div style={{font: 'normal normal 600 10px Noto Sans'}}>{descriptor}</div>
 		</div>
-	)
+	);
 }

--- a/frontend/src/components/dataTracker/StatPill.js
+++ b/frontend/src/components/dataTracker/StatPill.js
@@ -4,7 +4,7 @@ import { gcOrange } from '../common/gc-colors';
 export default function StatPill({ stat, descriptor }) {
 	return (
 		<div style={{border: '1px solid #E4E4E4', borderRadius: '10px', padding: 15, textAlign: 'center', marginBottom: 20}}>
-			<div style={{color: gcOrange, font: 'normal normal 600 28px/20px Noto Sans', marginBottom: 5}}>{stat}</div>
+			<div style={{color: gcOrange, font: 'normal normal 600 28px/20px Noto Sans', marginBottom: 5}}>{stat ? stat : 0}</div>
 			<div style={{font: 'normal normal 600 10px Noto Sans'}}>{descriptor}</div>
 		</div>
 	);

--- a/frontend/src/components/dataTracker/StatPill.js
+++ b/frontend/src/components/dataTracker/StatPill.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { gcOrange } from '../common/gc-colors'
+
+export default function StatPill({ stat, descriptor }) {
+	return (
+		<div style={{border: '1px solid #E4E4E4', borderRadius: '10px', padding: 15, textAlign: 'center', marginBottom: 20}}>
+			<div style={{color: gcOrange, font: 'normal normal 600 28px/20px Noto Sans', marginBottom: 5}}>{stat}</div>
+			<div style={{font: 'normal normal 600 10px Noto Sans'}}>{descriptor}</div>
+		</div>
+	)
+}


### PR DESCRIPTION
## Description

Adds ingest statistics in the data status tracker. Includes a graph of documents ingested by month, the number of total docs ingested, and the number of sources. Mock-ups found here: https://xd.adobe.com/view/80cc0bf0-a26f-48d2-915f-5f3a32cb83b3-d59f/screen/56b00e37-2bc8-4101-a97e-aeb1aeee69d8/specs/  
Also adds a link to sources in the Progress table and allows you to sort by source. 

## !vibez

Vibez are bueno.

## Related Issue/Ticket

[UOT-130405](https://jira.di2e.net/browse/UOT-130405)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

* Navigate to the Data Status Tracker on the left nav bar. Both the Progress and Documents tabs should include the new graph and stats. <u>Some data may not be on your local so you should set you postgres to point at RDS.</u>
* On the Progress tab, click a few sources to make sure the links work. 
* Sort the Progress table by source by clicking column header once for ascending and again for descending. 

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [x] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
