### PR TITLE
fix crash from selecting input paragraph with no results

### DIFF
--- a/frontend/src/components/analystTools/GCDocumentsComparisonTool.js
+++ b/frontend/src/components/analystTools/GCDocumentsComparisonTool.js
@@ -334,7 +334,7 @@ const GCDocumentsComparisonTool = (props) => {
 					break;
 			}
 			const sortedDocs = newViewableDocs.sort(sortFunc);
-			if(!selectedParagraph) {
+			if(!selectedParagraph && sortedDocs.length) {
 				setSelectedParagraph(sortedDocs[0].paragraphs[0]);
 				setCompareDocument(sortedDocs[0]);
 			}


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail, must use a list if more than 2-3 distinct items -->
Fixes a bug in the DCT where selecting an input paragraph with no results causes a crash.

## !vibez

Sad vibez from letting a bug get in originally.

## Related Issue/Ticket

[UOT-136563](https://jira.di2e.net/browse/UOT-136563)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

If testing locally, will need to comment out the iframe in both GCDocumentComparisonTool.js and GCResponsibilityDocumentExplorer.js. Navigate to the DCT. Make a search with at least one paragraph returning results and another not. (ex: 'the director for the dia' and 'sldnfljaksnd d lajindlca dp al'). Select the gibberish paragraph and ensure a 'no results' message appears and the app doesn't crash. 

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
