### PR TITLE
fixed the tutorial, clears filters before starting

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -298,7 +298,7 @@ app.post('/api/auth/token', async function (req, res) {
 });
 
 app.use(async function (req, res, next) {
-	const routesAllowedWithoutToken = ['/api/gamechanger/modular/getAllCloneMeta'];
+	const routesAllowedWithoutToken = ['/api/gamechanger/modular/getAllCloneMeta', '/api/tutorialOverlay', '/api/userAppVersion'];
 
 	if (routesAllowedWithoutToken.includes(req.path)) {
 		next();
@@ -318,7 +318,7 @@ app.use(async function (req, res, next) {
 			if (req.url.includes('getThumbnail')) {
 				next();
 			} else {
-				res.status(403).send({code: 'not authorized'});
+				res.status(403).send({ code: 'not authorized' });
 			}
 		}
 	}

--- a/frontend/src/components/modules/policy/policyNavigationHandler.js
+++ b/frontend/src/components/modules/policy/policyNavigationHandler.js
@@ -51,6 +51,10 @@ const getToolTheme = (cloneData) => {
 	};
 };
 
+const resetAdvancedSettings = (dispatch) => {
+	dispatch({ type: 'RESET_SEARCH_SETTINGS' });
+};
+
 const PolicyNavigationHandler = {
 	getToolState: (state) => {
 		return {
@@ -107,6 +111,7 @@ const PolicyNavigationHandler = {
 						<HoverNavItem
 							centered
 							onClick={() => {
+								resetAdvancedSettings(dispatch);
 								setState(dispatch, {
 									showTutorial: true,
 									clickedTutorial: true,
@@ -305,6 +310,7 @@ const PolicyNavigationHandler = {
 					<GCTooltip title="How-to, features, and tips" placement="right" arrow>
 						<HoverNavItem
 							onClick={() => {
+								resetAdvancedSettings(dispatch);
 								setState(dispatch, {
 									showTutorial: true,
 									clickedTutorial: true,

--- a/frontend/src/components/tutorial/Tutorial.js
+++ b/frontend/src/components/tutorial/Tutorial.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { gcOrange } from '../../components/common/gc-colors';
 import TutorialOverlay from '@dod-advana/advana-tutorial-overlay/dist/TutorialOverlay';
 import { setState } from '../../utils/sharedFunctions';
-import { initializeTutorial } from '@dod-advana/advana-tutorial-overlay/dist/TutorialOverlayHelper';
+// import { initializeTutorial } from '@dod-advana/advana-tutorial-overlay/dist/TutorialOverlayHelper';
 // import { useMountEffect } from '../../utils/gamechangerUtils';
 
 const Tutorial = (props) => {

--- a/frontend/src/components/tutorial/Tutorial.js
+++ b/frontend/src/components/tutorial/Tutorial.js
@@ -1,45 +1,23 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { gcOrange } from '../../components/common/gc-colors';
 import TutorialOverlay from '@dod-advana/advana-tutorial-overlay/dist/TutorialOverlay';
 import { setState } from '../../utils/sharedFunctions';
 import { initializeTutorial } from '@dod-advana/advana-tutorial-overlay/dist/TutorialOverlayHelper';
-import { useMountEffect } from '../../utils/gamechangerUtils';
-
-async function initTutorial(dispatch, cloneName) {
-	try {
-		let nameToUse = '';
-		switch (cloneName) {
-			case 'gamechanger':
-				nameToUse = 'gamechanger';
-				break;
-			default:
-				nameToUse = '';
-				break;
-		}
-		const { componentStepNumbers, tutorialJoyrideSteps } =
-			await initializeTutorial(nameToUse);
-		setState(dispatch, {
-			componentStepNumbers,
-			tutorialJoyrideSteps,
-		});
-	} catch (err) {
-		console.error(err.message);
-	}
-}
+// import { useMountEffect } from '../../utils/gamechangerUtils';
 
 const Tutorial = (props) => {
+	const { tutorialData } = props;
 	const { state, dispatch } = props.context;
-
-	useMountEffect(() => {
-		if (
-			!sessionStorage.getItem(
-				`${state.cloneData.clone_name}-userVersionChecked`
-			)
-		) {
-			initTutorial(dispatch, state.cloneData.clone_name);
+	useEffect(() => {
+		if ((Object.keys(state.componentStepNumbers).length === 0 || state.tutorialJoyrideSteps.length === 0)) {
+			const { componentStepNumbers, tutorialJoyrideSteps } = tutorialData;
+			setState(dispatch, {
+				componentStepNumbers,
+				tutorialJoyrideSteps,
+			});
 		}
-	});
+	}, [state, dispatch, tutorialData]);
 
 	const resetState = () => {
 		dispatch({ type: 'RESET_STATE' });

--- a/frontend/src/components/tutorial/Tutorial.js
+++ b/frontend/src/components/tutorial/Tutorial.js
@@ -10,7 +10,7 @@ const Tutorial = (props) => {
 	const { tutorialData } = props;
 	const { state, dispatch } = props.context;
 	useEffect(() => {
-		if ((Object.keys(state.componentStepNumbers).length === 0 || state.tutorialJoyrideSteps.length === 0)) {
+		if (tutorialData !== null && ((Object.keys(state.componentStepNumbers).length === 0 || state.tutorialJoyrideSteps.length === 0))) {
 			const { componentStepNumbers, tutorialJoyrideSteps } = tutorialData;
 			setState(dispatch, {
 				componentStepNumbers,

--- a/frontend/src/containers/GameChangerPage.js
+++ b/frontend/src/containers/GameChangerPage.js
@@ -35,7 +35,7 @@ export const scrollToContentTop = () => {
 };
 
 const GameChangerPage = (props) => {
-	const { cloneData, history, jupiter } = props;
+	const { cloneData, history, jupiter, tutorialData } = props;
 
 	const cloneName = cloneData.clone_name;
 	const context = useContext(getContext(cloneName));
@@ -43,7 +43,7 @@ const GameChangerPage = (props) => {
 	const [jiraFeedback, setJiraFeedback] = useState(false);
 
 	useEffect(() => {
-		gameChangerAPI.getJiraFeedbackMode().then(({data}) => {
+		gameChangerAPI.getJiraFeedbackMode().then(({ data }) => {
 			setJiraFeedback(data.value === 'true');
 		});
 	}, []);
@@ -78,26 +78,26 @@ const GameChangerPage = (props) => {
 					<Notifications context={context} />
 
 					{/* User Feedback */}
-					{jiraFeedback ? 
-						<Feedback 
-							open={state.showFeedbackModal} 
-							setOpen={()=>setState(dispatch, {showFeedbackModal: false})}
+					{jiraFeedback ?
+						<Feedback
+							open={state.showFeedbackModal}
+							setOpen={() => setState(dispatch, { showFeedbackModal: false })}
 							handleSubmit={sendJiraFeedback}
 						/> :
 						<UserFeedback context={context} />
 					}
 					{/* Crowd Sourcing */}
-					{ cloneData.show_crowd_source && (
-						<GameChangerAssist context={context} primaryColor={gcOrange} /> 
+					{cloneData.show_crowd_source && (
+						<GameChangerAssist context={context} primaryColor={gcOrange} />
 					)}
 
 					{/* Crowd Sourcing */}
 					{/* { cloneData.show_crowd_source && (
 						<ResponsibilityAssist context={context} primaryColor={gcOrange} /> 
 					)} */}
-					
+
 					{/* Tutorial Overlay */}
-					{cloneData.show_tutorial && <Tutorial context={context} />}
+					{cloneData.show_tutorial && <Tutorial context={context} tutorialData={tutorialData} />}
 
 					{/* Search Banner */}
 					{state.cloneDataSet && (


### PR DESCRIPTION
## Description
Tutorial runs with filters Selected, this ticket resets filters before starting the tutorial

## !vibez
there was a little bit of a rabbit hole, had to fix tutorials on local first, and found another one on the 

## Related Issue/Ticket
https://jira.di2e.net/browse/UOT-137569

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions
- make sure this is in the frontend .env: `REACT_APP_TUTORIAL_HREF=http://localhost:8990/`
`REACT_APP_ENABLE_TUTORIAL=true`
- open this branch on local
- test out the tutorial to make sure it works on local
- turn a filter on, and then run the tutorial again; see if the filters get reset before starting the tutorial. 

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
