### PR TITLE
handling 'S' case of plural forms

### DIFF
--- a/frontend/src/components/modules/jbook/jbookSearchMatrixHandler.js
+++ b/frontend/src/components/modules/jbook/jbookSearchMatrixHandler.js
@@ -80,10 +80,12 @@ const handleFilterChange = (event, state, dispatch, type) => {
 const renderFilterCheckboxes = (state, dispatch, classes, type, displayName) => {
 
 	const endsInY = displayName[displayName.length - 1] === 'y';
+	const endsInS = displayName[displayName.length - 1] === 's';
+
 
 	const allSelected = `${type}AllSelected`;
-	const allText = `All ${endsInY ? displayName.slice(0, displayName.length - 1) : displayName}${endsInY ? 'ies' : 's'}`;
-	const specificText = `Specific ${endsInY ? displayName.slice(0, displayName.length - 1) : displayName}${endsInY ? 'ies' : 's'}`;
+	const allText = `All ${endsInY ? displayName.slice(0, displayName.length - 1) : displayName}${endsInY ? 'ies' : (endsInS ? 'es' : 's')}`;
+	const specificText = `Specific ${endsInY ? displayName.slice(0, displayName.length - 1) : displayName}${endsInY ? 'ies' : (endsInS ? 'es' : 's')}`;
 	const specificSelected = `${type}SpecificSelected`;
 	const options = state.defaultOptions[type];
 


### PR DESCRIPTION
## Description
jbook filters pluralized "status" incorrectly, code turns it into "statuss"

## !vibez
EZ $

## Related Issue/Ticket
no ticket, I found this one in the wild and decided to knock it out really fast

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions
navigate to #/jbook, open the review status filter, make sure it says "All review statuses" and "Specific review statuses"

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
