### PR TITLE
fix overlapping reference sections

### DIFF
--- a/frontend/src/components/documentViewer/DocumentExplorer.js
+++ b/frontend/src/components/documentViewer/DocumentExplorer.js
@@ -598,7 +598,7 @@ const DocumentExplorer = ({
 						title={'Metadata'}
 						hideHeader={isEDA}
 					/>
-					<div style={{ marginTop: -18 }}>
+					<div>
 						{' '}
 						<SimpleTable
 							tableClass={'magellan-table'}

--- a/frontend/src/components/modules/default/defaultDocumentExplorer.js
+++ b/frontend/src/components/modules/default/defaultDocumentExplorer.js
@@ -616,7 +616,7 @@ export default function DocumentExplorer({
 					disableWrap={true}
 					title={'Metadata'}
 				/>
-				<div style={{ marginTop: -18 }}>
+				<div>
 					{' '}
 					<SimpleTable
 						tableClass={'magellan-table'}

--- a/frontend/src/components/modules/eda/edaDocumentExplorer.js
+++ b/frontend/src/components/modules/eda/edaDocumentExplorer.js
@@ -594,7 +594,7 @@ export default function EDADocumentExplorer({
 						title={'Metadata'}
 						hideHeader={true}
 					/>
-					<div style={{ marginTop: -18 }}>
+					<div>
 						<SimpleTable
 							tableClass={'magellan-table'}
 							zoom={0.8}

--- a/frontend/src/components/modules/policy/policyCardHandler.js
+++ b/frontend/src/components/modules/policy/policyCardHandler.js
@@ -1569,7 +1569,7 @@ const PolicyCardHandler = {
 						title={'Metadata'}
 						hideHeader={!!state.listView}
 					/>
-					<div style={{ marginTop: -18 }}>
+					<div>
 						<SimpleTable
 							tableClass={'magellan-table'}
 							zoom={1}


### PR DESCRIPTION
## Description

Fixes issue where document Reference tables were overlapping the tables above them.
![image](https://user-images.githubusercontent.com/43630721/160194421-b1a940ec-ce9c-4fcb-8c19-abc01ab1e2c3.png)


## !vibez

Supa quick

## Related Issue/Ticket

[UOT-138317](https://jira.di2e.net/browse/UOT-138317)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

Make a search on GAMECHANGER. Flip some cards to make sure the Reference tables don't overlap. Go to document view in the top right. Check the meta data table on the right to make sure there is no overlap.

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
