### PR TITLE
multiple fixes for doc details page

### DIFF
--- a/frontend/src/components/common/SimpleTable.js
+++ b/frontend/src/components/common/SimpleTable.js
@@ -237,8 +237,19 @@ export default class SimpleTable extends React.Component {
 	};
 
 	render() {
-		const { rows, colKeys, columnMap, onRowClick, height, zoom, tableClass, dontScroll, inheritOverflow, margin } =
-			this.props;
+		const {
+			rows,
+			colKeys,
+			columnMap,
+			onRowClick,
+			height,
+			maxHeight,
+			zoom,
+			tableClass,
+			dontScroll,
+			inheritOverflow,
+			margin,
+		} = this.props;
 		if (rows.length === 0) return <i></i>;
 		const cols = colKeys || _.keys(rows[0]);
 		const head = this.getHeader(cols, columnMap);
@@ -255,6 +266,7 @@ export default class SimpleTable extends React.Component {
 			container: {
 				width: '100%',
 				height,
+				maxHeight,
 				overflow: 'auto',
 				margin,
 			},

--- a/frontend/src/components/details/documentDetailsPage.js
+++ b/frontend/src/components/details/documentDetailsPage.js
@@ -12,12 +12,7 @@ import { MainContainer } from '../../containers/GameChangerDetailsPage';
 import { MemoizedPolicyGraphView } from '../graph/policyGraphView';
 import { trackEvent } from '../telemetry/Matomo';
 import Pagination from 'react-js-pagination';
-import {
-	getTrackingNameForFactory,
-	numberWithCommas,
-	policyMetadata,
-	getMetadataForPropertyTable,
-} from '../../utils/gamechangerUtils';
+import { getTrackingNameForFactory, policyMetadata, getMetadataForPropertyTable } from '../../utils/gamechangerUtils';
 import { Card } from '../cards/GCCard';
 import Permissions from '@dod-advana/advana-platform-ui/dist/utilities/permissions';
 import '../../containers/gamechanger.css';
@@ -265,9 +260,21 @@ const DocumentDetailsPage = (props) => {
 				});
 				const emptyDoc = { ...document };
 				Object.keys(emptyDoc).forEach((prop) => (emptyDoc[prop] = null));
-				notInCorpusDocs?.forEach((doc) =>
-					docsVisible.push({ ...emptyDoc, display_title_s: doc, type: 'document', notInCorpus: true })
-				);
+				if (notInCorpusDocs) {
+					for (
+						let i = docsReferencedPage * 10 - documentObj.docCount - 10;
+						i < docsReferencedPage * 10 - documentObj.docCount;
+						i++
+					) {
+						if (i < 0 || !notInCorpusDocs[i]) continue;
+						docsVisible.push({
+							...emptyDoc,
+							display_title_s: notInCorpusDocs[i],
+							type: 'document',
+							notInCorpus: true,
+						});
+					}
+				}
 				break;
 			case 'referencedByDocs':
 				docsVisible = referencedByDocs.docs.slice(
@@ -304,21 +311,16 @@ const DocumentDetailsPage = (props) => {
 		return (
 			<div className={`related-documents`} style={{ width: '100%' }}>
 				<div style={{ display: 'flex', justifyContent: 'space-between' }}>
-					<div style={styles.resultsCount}>
-						{runningQuery
-							? 'Searching for documents...'
-							: documentObj.docCount > 0
-							? `${numberWithCommas(documentObj.docCount)} results found in ${
-									documentObj.timeFound
-							  } seconds`
-							: ''}
-					</div>
 					<div style={{ display: 'flex' }} className={'gcPagination'}>
 						{!runningQuery && documentObj.docCount > 0 && (
 							<Pagination
 								activePage={docPage}
 								itemsCountPerPage={10}
-								totalItemsCount={documentObj.docCount}
+								totalItemsCount={
+									section === 'docsReferenced'
+										? notInCorpusDocs?.length + documentObj.docCount
+										: documentObj.docCount
+								}
 								pageRangeDisplayed={8}
 								onChange={(page) => {
 									trackEvent(
@@ -405,7 +407,6 @@ const DocumentDetailsPage = (props) => {
 											}}
 											rows={metadata || []}
 											height={'auto'}
-											dontScroll={true}
 											colWidth={colWidth}
 											disableWrap={true}
 											title={'Metadata'}
@@ -420,7 +421,7 @@ const DocumentDetailsPage = (props) => {
 											}}
 											rows={refList}
 											height={'auto'}
-											dontScroll={true}
+											maxHeight={500}
 											colWidth={{ minWidth: '25%', maxWidth: '25%' }}
 											disableWrap={true}
 										/>


### PR DESCRIPTION
## Description

Removes results found in seconds displayed at top of reference sections. Limits sizes of meta table reference section and scrolls if too large. Makes non-corpus 'lite card' part of pagination so thy don't display all at once. 

## !vibez

Fixin'

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions
Make a search on GC. Sort by references. Go to the details page on one of the first results with a lot of references. Make sure everything listed in the description looks good. 'Lite' cards in the referenced section will always be at the end. Go through pagination until you see them and make sure they render correctly and in the right amount (10). 

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
