### PR TITLE
using an npm package to handle all plural cases

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -59,6 +59,7 @@
 		"node-sass": "6.0.1",
 		"npm-force-resolutions": "0.0.10",
 		"piwik-react-router": "0.12.1",
+		"pluralize": "^8.0.0",
 		"prop-types": "15.8.1",
 		"react": "17.0.2",
 		"react-bottom-scroll-listener": "5.0.0",

--- a/frontend/src/components/analystTools/GCDocumentsComparisonTool.js
+++ b/frontend/src/components/analystTools/GCDocumentsComparisonTool.js
@@ -147,9 +147,6 @@ const getPresearchData = async (state, dispatch) => {
 		const typeFilters = {};
 		for (const key in resp.data.types) {
 			let name = resp.data.types[key];
-			if (name.slice(-1) !== 's') {
-				name = name + 's';
-			}
 			typeFilters[name] = false;
 		}
 		const newSearchSettings = _.cloneDeep(state.analystToolsSearchSettings);
@@ -212,10 +209,10 @@ const GCDocumentsComparisonTool = (props) => {
 			const typeCount = {};
 
 			returnedDocs.forEach((doc) => {
-				if (typeCount[doc.display_doc_type_s + 's']) {
-					typeCount[doc.display_doc_type_s + 's']++;
+				if (typeCount[doc.display_doc_type_s]) {
+					typeCount[doc.display_doc_type_s]++;
 				} else {
-					typeCount[doc.display_doc_type_s + 's'] = 1;
+					typeCount[doc.display_doc_type_s] = 1;
 				}
 				if (sourceCount[doc.display_org_s]) {
 					sourceCount[doc.display_org_s]++;

--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -342,10 +342,6 @@ const PolicySearchHandler = {
 
 						doc_types.forEach((element) => {
 							var docTypeName = element.key;
-							if (docTypeName.slice(-1) !== 's') {
-								docTypeName = docTypeName + 's';
-							}
-
 							docTypeMap[docTypeName] = docTypeMap[docTypeName]
 								? docTypeMap[docTypeName] + element.doc_count
 								: element.doc_count;
@@ -722,9 +718,6 @@ const PolicySearchHandler = {
 			const typeFilters = {};
 			for (const key in resp.data.types) {
 				let name = resp.data.types[key];
-				if (name.slice(-1) !== 's') {
-					name = name + 's';
-				}
 				typeFilters[name] = false;
 			}
 			const newSearchSettings = _.cloneDeep(state.searchSettings);

--- a/frontend/src/components/modules/policy/policySearchMatrixHandler.js
+++ b/frontend/src/components/modules/policy/policySearchMatrixHandler.js
@@ -1,4 +1,6 @@
 import React from 'react';
+import Pluralize from 'pluralize';
+
 import GCAccordion from '../../common/GCAccordion';
 import GCButton from '../../common/GCButton';
 import _ from 'lodash';
@@ -316,7 +318,7 @@ const handleSelectArchivedCongress = (event, state, dispatch) => {
 	});
 };
 
-const handleTypeFilterChangeLocal = (event, state, dispatch, searchbar) => {
+const handleTypeFilterChangeLocal = (event, type, state, dispatch, searchbar) => {
 	const newSearchSettings = _.cloneDeep(state.searchSettings);
 	let typeName = event.target.name;
 	if (typeName.includes('(')) {
@@ -324,7 +326,7 @@ const handleTypeFilterChangeLocal = (event, state, dispatch, searchbar) => {
 	}
 	newSearchSettings.typeFilter = {
 		...newSearchSettings.typeFilter,
-		[typeName]: event.target.checked,
+		[type]: event.target.checked,
 	};
 	if (searchbar) {
 		setState(dispatch, {
@@ -423,11 +425,13 @@ const renderTypes = (state, dispatch, classes, searchbar = false) => {
 					<FormGroup row style={{ marginLeft: '10px', width: '100%' }}>
 						{state.searchSettings.specificTypesSelected &&
 							Object.keys(typeFilter).map((type, index) => {
+								let typeString = Pluralize(type);
+
 								if (index < 10 || state.seeMoreTypes) {
 									return (
 										<FormControlLabel
-											key={`${type}`}
-											value={`${type}`}
+											key={`${typeString}`}
+											value={`${typeString}`}
 											classes={{
 												root: classes.rootLabel,
 												label: classes.checkboxPill,
@@ -438,14 +442,14 @@ const renderTypes = (state, dispatch, classes, searchbar = false) => {
 														root: classes.rootButton,
 														checked: classes.checkedButton,
 													}}
-													name={`${type}`}
+													name={`${typeString}`}
 													checked={state.searchSettings.typeFilter[type]}
 													onClick={(event) =>
-														handleTypeFilterChangeLocal(event, state, dispatch, true)
+														handleTypeFilterChangeLocal(event, type, state, dispatch)
 													}
 												/>
 											}
-											label={`${type}`}
+											label={`${typeString}`}
 											labelPlacement="end"
 										/>
 									);
@@ -534,11 +538,12 @@ const renderTypes = (state, dispatch, classes, searchbar = false) => {
 					<FormGroup row style={{ marginLeft: '10px', width: '100%' }}>
 						{state.searchSettings.specificTypesSelected &&
 							Object.keys(betterTypeData).map((type) => {
+								let typeString = Pluralize(type);
 								return (
 									<FormControlLabel
 										disabled={!betterTypeData[type] && !state.searchSettings.typeFilter[type]}
-										key={`${type} (${betterTypeData[type]})`}
-										value={`${type} (${betterTypeData[type]})`}
+										key={`${typeString} (${betterTypeData[type]})`}
+										value={`${typeString} (${betterTypeData[type]})`}
 										classes={{
 											root: classes.rootLabel,
 											label: classes.checkboxPill,
@@ -549,12 +554,14 @@ const renderTypes = (state, dispatch, classes, searchbar = false) => {
 													root: classes.rootButton,
 													checked: classes.checkedButton,
 												}}
-												name={`${type} (${betterTypeData[type]})`}
+												name={`${typeString} (${betterTypeData[type]})`}
 												checked={state.searchSettings.typeFilter[type]}
-												onClick={(event) => handleTypeFilterChangeLocal(event, state, dispatch)}
+												onClick={(event) =>
+													handleTypeFilterChangeLocal(event, type, state, dispatch)
+												}
 											/>
 										}
-										label={`${type} (${betterTypeData[type]})`}
+										label={`${typeString} (${betterTypeData[type]})`}
 										labelPlacement="end"
 									/>
 								);

--- a/frontend/src/utils/gamechangerUtils.js
+++ b/frontend/src/utils/gamechangerUtils.js
@@ -533,7 +533,7 @@ export const getTypeQuery = (allTypesSelected, types) => {
 		let query = [];
 		for (let type in types) {
 			if (types[type]) {
-				query.push(type.substring(0, type.length - 1));
+				query.push(type);
 			}
 		}
 		return query;


### PR DESCRIPTION
# Description
-filters had incorrect plural handling: Policys was being printed instead of Policies
because there are a bunch of edge cases and I was not about to try to handle them all (index => indices), I imported pluralize npm package to handle plural forms. I also updated the logic to only post the plural form on the frontend, and not convert back and forth from plural and singluar for map values in state. 

# !vibez
spent a little too long on this one, but cleaned up some logic so it's ok

## Related Issue/Ticket
https://jira.di2e.net/browse/UOT-142577

# Types of changes
[ X ] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)
[ ] Optimization (provides speedup with no functional changes)
[ ] Breaking change (fix or feature that would cause existing functionality to change)

# Smoke testing instructions
in GC: 
- check types in adv filters (right side of searchbar). filters should be plural form, still working normally. 
- check type filters in card view page, those should also be working normally, but words are in plural form.

# Checklist:
[ ] Documentation updated
[ ] Unit tests added/updated
[ ] Smoke testing relevant to authentication needed
[ ] Clones involved and accounted for
[ ] RDS migrations or other data manipulation necessary
[ ] Dev tools or other infrastructure changed