### PR TITLE
fix overflow issues on doc details page meta

### DIFF
--- a/frontend/src/components/details/documentDetailsPage.js
+++ b/frontend/src/components/details/documentDetailsPage.js
@@ -96,10 +96,13 @@ const DocumentDetailsPage = (props) => {
 		if (document) {
 			const data = getMetadataForPropertyTable(document);
 			let favoritableData = policyMetadata(document);
-			favoritableData = [...favoritableData, ...addFavoriteTopicToMetadata(data, userData, {}, cloneData, '')];
+			favoritableData = [
+				...favoritableData,
+				...addFavoriteTopicToMetadata(data, userData, {}, cloneData, '', '150px'),
+			];
 			setMetadata(favoritableData);
 		}
-	}, [document]);
+	}, [cloneData, document, userData]);
 
 	useEffect(() => {
 		if (document) {

--- a/frontend/src/components/modules/policy/policyCardHandler.js
+++ b/frontend/src/components/modules/policy/policyCardHandler.js
@@ -82,15 +82,15 @@ const colWidth = {
 const FavoriteTopic = styled.button`
 	border: none;
 	height: 25px;
+	max-width: ${({ maxWidth }) => maxWidth ?? 'none'};
+	position: relative;
 	border-radius: 15px;
 	background-color: white;
 	color: black;
 	white-space: nowrap;
 	text-align: center;
-	display: inline-block;
-	padding-left: 5px;
-	padding-right: 5px;
-	margin-left: 6px;
+	display: inline-flex;
+	padding: 0px 5px;
 	margin-right: 6px;
 	margin-bottom: 3px;
 	cursor: pointer;
@@ -157,9 +157,6 @@ const StyledFrontCardHeader = styled.div`
 
 			.text {
 				margin-top: ${({ listView }) => (listView ? '10px' : '0px')};
-				-webkit-line-clamp: 2;
-				display: -webkit-box;
-				-webkit-box-orient: vertical;
 			}
 
 			.list-view-arrow {
@@ -706,7 +703,7 @@ const FavoriteTopicFromCardBack = ({ topic, favorited, dispatch, searchText, clo
 	);
 };
 
-export const addFavoriteTopicToMetadata = (data, userData, dispatch, cloneData, searchText) => {
+export const addFavoriteTopicToMetadata = (data, userData, dispatch, cloneData, searchText, maxWidth) => {
 	const { favorite_topics = null } = userData ?? {};
 	let favorites = [];
 
@@ -731,21 +728,52 @@ export const addFavoriteTopicToMetadata = (data, userData, dispatch, cloneData, 
 						topic = topic.trim();
 						const favorited = favorites.includes(topic);
 						return (
-							<FavoriteTopic key={index} favorited={favorited}>
-								<span
-									onClick={() => {
-										trackEvent(
-											getTrackingNameForFactory(cloneData.clone_name),
-											'TopicOpened',
-											topic
-										);
-										window.open(
-											`#/gamechanger-details?cloneName=${cloneData.clone_name}&type=topic&topicName=${topic}`
-										);
-									}}
-								>
-									{topic}
-								</span>
+							<FavoriteTopic key={index} favorited={favorited} maxWidth={maxWidth}>
+								{maxWidth ? (
+									<GCTooltip title={topic} placement="top" arrow>
+										<div
+											style={{
+												overflow: 'hidden',
+												textOverflow: 'ellipsis',
+												marginTop: '-1px',
+												maxWidth: 'calc(100% - 15px)',
+											}}
+											onClick={() => {
+												trackEvent(
+													getTrackingNameForFactory(cloneData.clone_name),
+													'TopicOpened',
+													topic
+												);
+												window.open(
+													`#/gamechanger-details?cloneName=${cloneData.clone_name}&type=topic&topicName=${topic}`
+												);
+											}}
+										>
+											{topic}
+										</div>
+									</GCTooltip>
+								) : (
+									<div
+										style={{
+											overflow: 'hidden',
+											textOverflow: 'ellipsis',
+											marginTop: '-1px',
+											maxWidth: 'calc(100% - 15px)',
+										}}
+										onClick={() => {
+											trackEvent(
+												getTrackingNameForFactory(cloneData.clone_name),
+												'TopicOpened',
+												topic
+											);
+											window.open(
+												`#/gamechanger-details?cloneName=${cloneData.clone_name}&type=topic&topicName=${topic}`
+											);
+										}}
+									>
+										{topic}
+									</div>
+								)}
 								<FavoriteTopicFromCardBack
 									topic={topic}
 									favorited={favorited}


### PR DESCRIPTION
## Description

On the document details page in the meta table, long topic names were causing words in other rows to be cut off from overflow issues. Added a maxWidth property to the topic component to fix it. 

## !vibez

Super Duper

## Related Issue/Ticket

[UOT-140311](https://jira.di2e.net/browse/UOT-140311)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

<!--- Describe details on testing the ticket - endpoints to call, cURL requests, data objects, frontend pages, etc. -->
<!--- If there are multiple test cases, please list the expected input and output for each. -->

1. Search for: DoDM 1000.13  and open it's document details page
2. Make sure no meta data is cut off and that the topics look good.  

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed

## Reminders:
<!-- Not required, just check for them for good practice -->
- try catch statements
- comments
- ... tbd