### PR TITLE
fix size of RE export button

### DIFF
--- a/frontend/src/components/analystTools/GCResponsibilityExplorer.js
+++ b/frontend/src/components/analystTools/GCResponsibilityExplorer.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import _ from 'lodash';
 import { FormControl, InputLabel, MenuItem, Select } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-import Icon from '@material-ui/core/Icon';
+import ExportIcon from '../../images/icon/Export.svg';
 import { useBottomScrollListener } from 'react-bottom-scroll-listener';
 import { trackEvent } from '../telemetry/Matomo';
 import GCButton from '../common/GCButton';
@@ -199,19 +199,36 @@ export default function GCResponsibilityExplorer({ state, dispatch }) {
 		<div>
 			<div className="row" style={{ height: 65, margin: 0, padding: 0 }}>
 				<div style={{ display: 'flex', justifyContent: 'flex-end', padding: 0 }}>
-					<GCButton
-						onClick={exportCSV}
+					<span
 						style={{
-							minWidth: 50,
-							padding: '0px 7px',
 							margin: '6px 10px 0px 0px',
-							height: 50,
 						}}
 					>
-						<GCToolTip title="Export" placement="bottom" arrow enterDelay={500}>
-							<Icon className="fa fa-external-link" style={{ paddingTop: 2, transform: 'scale(1.3)' }} />
+						<GCToolTip title="Export" placement="top" arrow enterDelay={500}>
+							<span>
+								<GCButton
+									onClick={exportCSV}
+									style={{
+										minWidth: 50,
+										padding: '0px 7px',
+										height: 50,
+										marginLeft: 0,
+									}}
+									disabled={Object.keys(docResponsibilityData).length ? false : true}
+								>
+									<img
+										src={ExportIcon}
+										style={{
+											margin: '0 0 3px 3px',
+											width: 15,
+											opacity: Object.keys(docResponsibilityData).length ? 1 : 0.6,
+										}}
+										alt="export"
+									/>
+								</GCButton>
+							</span>
 						</GCToolTip>
-					</GCButton>
+					</span>
 					<FormControl
 						variant="outlined"
 						classes={{ root: classes.root }}


### PR DESCRIPTION
## Description

Fixes the size of the export button icon of the Responsibility Explorer. Also disables the button now if no results are returned after filters applied. 

Improperly sized icon: 
<img width="716" alt="image" src="https://user-images.githubusercontent.com/43630721/166709560-f50da639-6db4-403d-84b9-d20f21c985a8.png">

## !vibez

Yay

## Related Issue/Ticket

[UOT-143754](https://jira.di2e.net/browse/UOT-143754)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

* Navigate to the Analytics Tools to get to the Responsibility Explorer. 
* Make sure the export button sizing looks correct. 
* Add gibberish in the responsibility filter to return no results. Ensure the export button is disabled. 

## Checklist:
<!--- Not all of these are required, but it servers as a reminder for the pull requester and helps the reviewer know what is covered-->

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed

## Reminders:
<!-- Not required, just check for them for good practice -->
- try catch statements
- comments
- ... tbd