### PR TITLE
Feature/uot 141982 doc compare changes

### DIFF
--- a/backend/node_app/controllers/analystToolsController.js
+++ b/backend/node_app/controllers/analystToolsController.js
@@ -83,13 +83,12 @@ class AnalystToolsController {
 
 				paragraphResults.forEach((result) => {
 					Object.keys(result).forEach((id) => {
-						if (result[id].id && result[id]?.score >= 0.65) {
-							resultsObject[result[id].id] = {
-								score: result[id].score,
-								text: result[id].text,
-								paragraphIdBeingMatched: result.paragraphIdBeingMatched,
-							};
-						}
+						resultsObject[result[id].id] = {
+							score: result[id].score,
+							text: result[id].text,
+							paragraphIdBeingMatched: result.paragraphIdBeingMatched,
+							score_display: result[id].score_display,
+						};
 					});
 				});
 

--- a/backend/node_app/lib/mlApiClient.js
+++ b/backend/node_app/lib/mlApiClient.js
@@ -21,6 +21,7 @@ const MLRoutes = {
 	expandTerms: `${mlBaseUrl}/expandTerms`,
 	questionAnswer: `${mlBaseUrl}/questionAnswer`,
 	transSentenceSearch: `${transformerBaseUrl}/transSentenceSearch`,
+	documentCompare: `${transformerBaseUrl}/documentCompare`,
 	transformResults: `${transformerBaseUrl}/transformerSearch`,
 	reloadModels: `${transformerBaseUrl}/reloadModels`,
 	downloadCorpus: `${transformerBaseUrl}/downloadCorpus`,
@@ -93,7 +94,7 @@ class MLApiClient {
 
 	async getSentenceTransformerResultsForCompare(searchText, userId = 'unknown', paragraphIdBeingMatched) {
 		const data = { text: searchText };
-		const returnData = await this.postData('transSentenceSearch', userId, data, '?num_results=15');
+		const returnData = await this.postData('documentCompare', userId, data, '?num_results=15');
 
 		return { ...returnData, paragraphIdBeingMatched };
 	}

--- a/backend/node_app/utils/searchUtility.js
+++ b/backend/node_app/utils/searchUtility.js
@@ -1347,8 +1347,11 @@ class SearchUtility {
 									transformTextMatch: paragraphResults[paragraph._source.id].text,
 									paragraphIdBeingMatched:
 										paragraphResults[paragraph._source.id].paragraphIdBeingMatched,
+									score_display: paragraphResults[paragraph._source.id].score_display,
 								});
 							});
+
+							result.paragraphs.sort((a, b) => b.score - a.score);
 
 							result.score /= result.paragraphs.length;
 						} else {

--- a/frontend/src/components/admin/MLDashboard/models.js
+++ b/frontend/src/components/admin/MLDashboard/models.js
@@ -66,6 +66,9 @@ export default (props) => {
 	const [currentSimModel, setCurrentSim] = useState('');
 	const [currentEncoder, setCurrentEncoder] = useState('');
 	const [currentSentenceIndex, setCurrentSentenceIndex] = useState('');
+	const [currentDocCompareSimModel, setCurrentDocCompareSim] = useState('');
+	const [currentDocCompareEncoder, setCurrentDocCompareEncoder] = useState('');
+	const [currentDocCompareIndex, setCurrentDocCompareIndex] = useState('');
 	const [currentQexp, setCurrentQexp] = useState('');
 	const [currentQa, setCurrentQa] = useState('');
 	const [currentJbook, setCurrentJbook] = useState('');
@@ -75,6 +78,7 @@ export default (props) => {
 	const [corpusCount, setCorpusCount] = useState(0);
 
 	const [selectedSentence, setSelectedSentence] = useState('');
+	const [docCompareSelectedSentence, setDocCompareSelectedSentence] = useState('');
 	const [selectedQEXP, setSelectedQEXP] = useState('');
 	const [selectedJbookQEXP, setSelectedJbookQEXP] = useState('');
 	const [selectedTopicModel, setSelectedTopicModel] = useState('');
@@ -127,6 +131,19 @@ export default (props) => {
 			setCurrentSim(current.data.sim_model ? current.data.sim_model.replace(/^.*[\\/]/, '') : '');
 			setCurrentSentenceIndex(
 				current.data.sentence_index ? current.data.sentence_index.replace(/^.*[\\/]/, '') : ''
+			);
+			setCurrentDocCompareEncoder(
+				current.data.doc_compare_encoder_model
+					? current.data.doc_compare_encoder_model.replace(/^.*[\\/]/, '')
+					: ''
+			);
+			setCurrentDocCompareSim(
+				current.data.doc_compare_sim_model ? current.data.doc_compare_sim_model.replace(/^.*[\\/]/, '') : ''
+			);
+			setCurrentDocCompareIndex(
+				current.data.doc_compare_sentence_index
+					? current.data.doc_compare_sentence_index.replace(/^.*[\\/]/, '')
+					: ''
 			);
 			setCurrentQexp(current.data.qexp_model ? current.data.qexp_model.replace(/^.*[\\/]/, '') : '');
 			setCurrentQa(current.data.qa_model ? current.data.qa_model.replace(/^.*[\\/]/, '') : '');
@@ -337,6 +354,9 @@ export default (props) => {
 			if (selectedSentence) {
 				params['sentence'] = selectedSentence;
 			}
+			if (docCompareSelectedSentence) {
+				params['doc_compare_sentence'] = docCompareSelectedSentence;
+			}
 			if (selectedQEXP) {
 				params['qexp'] = selectedQEXP;
 			}
@@ -516,10 +536,13 @@ export default (props) => {
 								<div style={{ paddingLeft: '15px' }}>Question Answer:</div>
 								<div style={{ paddingLeft: '15px' }}>Jbook QExp:</div>
 								<div style={{ paddingLeft: '15px' }}>Word Similarity:</div>
+								<div style={{ paddingLeft: '15px' }}>Doc Compare Sentence Index:</div>
 								<div style={{ paddingLeft: '15px' }}>Topic Model:</div>
 								<div style={{ paddingLeft: '15px' }}>Transformer:</div>
 								<div style={{ paddingLeft: '30px' }}>Encoder:</div>
 								<div style={{ paddingLeft: '30px' }}>Sim:</div>
+								<div style={{ paddingLeft: '30px' }}>Doc Compare Encoder:</div>
+								<div style={{ paddingLeft: '30px' }}>Doc Compare Sim:</div>
 							</div>
 							<div style={{ width: '65%' }} className="half">
 								<br />
@@ -531,11 +554,16 @@ export default (props) => {
 								{currentQa} <br />
 								{currentJbook} <br />
 								{currentWordSim} <br />
+								{currentDocCompareIndex} <br />
 								{currentTopicModel} <br />
 								<br />
 								{currentEncoder.replace(/^.*[\\/]/, '')}
 								<br />
 								{currentSimModel.replace(/^.*[\\/]/, '')}
+								<br />
+								{currentDocCompareEncoder.replace(/^.*[\\/]/, '')}
+								<br />
+								{currentDocCompareSimModel.replace(/^.*[\\/]/, '')}
 							</div>
 						</div>
 					</fieldset>
@@ -716,6 +744,29 @@ export default (props) => {
 									}}
 								>
 									{Object.keys(downloadedModelsList.transformers).map((name) => {
+										return (
+											<MenuItem style={{ fontSize: 'small' }} value={name}>
+												{name}
+											</MenuItem>
+										);
+									})}
+								</Select>
+							</div>
+							<div>
+								<div style={{ width: '120px', display: 'inline-block' }}>
+									DOC COMPARE SENTENCE EMBEDDINGS:
+								</div>
+								<Select
+									value={docCompareSelectedSentence}
+									onChange={(e) => setDocCompareSelectedSentence(e.target.value)}
+									name="labels"
+									style={{
+										fontSize: 'small',
+										minWidth: '200px',
+										margin: '10px',
+									}}
+								>
+									{Object.keys(downloadedModelsList.sentence).map((name) => {
 										return (
 											<MenuItem style={{ fontSize: 'small' }} value={name}>
 												{name}

--- a/frontend/src/components/analystTools/GCDocumentsComparisonTool.js
+++ b/frontend/src/components/analystTools/GCDocumentsComparisonTool.js
@@ -10,7 +10,7 @@ import GCAnalystToolsSideBar from './GCAnalystToolsSideBar';
 import { setState } from '../../utils/sharedFunctions';
 import LoadingIndicator from '@dod-advana/advana-platform-ui/dist/loading/LoadingIndicator';
 import { gcOrange } from '../common/gc-colors';
-import { handlePdfOnLoad, convertDCTScoreToText } from '../../utils/gamechangerUtils';
+import { handlePdfOnLoad } from '../../utils/gamechangerUtils';
 import GCTooltip from '../common/GCToolTip';
 import GCButton from '../common/GCButton';
 import ExportIcon from '../../images/icon/Export.svg';
@@ -610,9 +610,9 @@ const GCDocumentsComparisonTool = ({
 																						paragraph.page_num_i + 1
 																				  }, Par: ${
 																						paragraph.id.split('_')[1]
-																				  }, Similarity Score: ${convertDCTScoreToText(
-																						paragraph.score
-																				  )}`
+																				  }, Similarity Score: ${
+																						paragraph.score_display
+																				  }`
 																				: paragraph.par_raw_text_t}
 																		</span>
 																	</div>
@@ -805,13 +805,7 @@ const GCDocumentsComparisonTool = ({
 																			}}
 																		>
 																			{isHighlighted
-																				? `Page: ${
-																						paragraph.pageNumber
-																				  }, Par: ${
-																						paragraph.id
-																				  }, Similarity Score: ${convertDCTScoreToText(
-																						paragraph.score
-																				  )}`
+																				? `Page: ${paragraph.pageNumber}, Par: ${paragraph.id}, Similarity Score: ${paragraph.score_display}`
 																				: paragraph.text}
 																		</span>
 																	</div>

--- a/frontend/src/containers/GamechangerAdminPage.js
+++ b/frontend/src/containers/GamechangerAdminPage.js
@@ -1,4 +1,5 @@
 import React, { useState, useContext, useEffect } from 'react';
+import { Route, Switch, useRouteMatch } from 'react-router-dom';
 import { SlideOutToolContext } from '@dod-advana/advana-side-nav/dist/SlideOutMenuContext';
 import TitleBar from '../components/searchBar/TitleBar';
 import HomepageEditor from '../components/admin/HomepageEditor';
@@ -138,6 +139,7 @@ const GamechangerAdminPage = (props) => {
 
 	const [pageToView, setPageToView] = useState(PAGES.general);
 	const { setToolState, unsetTool } = useContext(SlideOutToolContext);
+	const { path } = useRouteMatch();
 
 	const renderSwitch = (page) => {
 		trackEvent('GAMECHANGER_Admin', 'ChangeAdminPage', 'onChange', page.toString());
@@ -203,7 +205,10 @@ const GamechangerAdminPage = (props) => {
 				cloneData={{ clone_name: 'gamechanger' }}
 			/>
 
-			{renderSwitch(pageToView)}
+			<Switch>
+				<Route exact path={`${path}/mldashboard`} component={MLDashboard} />
+				<Route path="*" component={() => renderSwitch(pageToView)} />
+			</Switch>
 		</div>
 	);
 };


### PR DESCRIPTION
Adds ability to select a different sentence model for DCT, shows paragraph score_display from response instead of front end mapping function.
The new endpoint accepts a score_mapping and cutoff and returns a score_display based on those, the defaults are in the search function of the model [https://github.com/dod-advana/gamechanger-ml/pull/118/files#diff-4a5256bbb7a0b3dfd18990e7640ec8895207b7fab1ec044046da1e6ce4424ba5](https://github.com/dod-advana/gamechanger-ml/pull/118/files#diff-4a5256bbb7a0b3dfd18990e7640ec8895207b7fab1ec044046da1e6ce4424ba5 )