### PR TITLE
fix case if pdf is capitalized in file extension

### DIFF
--- a/frontend/src/components/documentViewer/PDFViewer.js
+++ b/frontend/src/components/documentViewer/PDFViewer.js
@@ -50,7 +50,7 @@ export default function PDFViewer({ location }) {
 		setCloneIndex(query.get('cloneIndex'));
 	}, [query, filename]);
 
-	if (filename && filename.endsWith('pdf')) {
+	if (filename && filename.toLowerCase().endsWith('pdf')) {
 		return (
 			<iframe
 				title={'PDFViewer'}


### PR DESCRIPTION
## Description

When opening documents, files with capitalized 'PDF' file extension were treated as an html document. This fixes that issue.

## !vibez

Great success

## Related Issue/Ticket

[UOT-136552](https://jira.di2e.net/browse/UOT-136552)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

Honestly not sure the best way to test this one since no documents seem to exist in our dev corpus with this issue.


## Checklist:

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed