### PR TITLE
don't reset trending when searching

### DIFF
--- a/frontend/src/components/modules/cdo/cdoSearchHandler.js
+++ b/frontend/src/components/modules/cdo/cdoSearchHandler.js
@@ -91,7 +91,6 @@ const CDOSearchHandler = {
 			isCachedResult: false,
 			pageDisplayed: PAGE_DISPLAYED.main,
 			didYouMean: '',
-			trending: '',
 		});
 
 		const trimmed = searchText.trim();

--- a/frontend/src/components/modules/eda/edaSearchHandler.js
+++ b/frontend/src/components/modules/eda/edaSearchHandler.js
@@ -82,7 +82,6 @@ const EdaSearchHandler = {
 			isCachedResult: false,
 			pageDisplayed: PAGE_DISPLAYED.main,
 			didYouMean: '',
-			trending: '',
 		});
 
 		const trimmed = searchText.trim();

--- a/frontend/src/components/modules/globalSearch/globalSearchHandler.js
+++ b/frontend/src/components/modules/globalSearch/globalSearchHandler.js
@@ -53,7 +53,6 @@ const GlobalSearchHandler = {
 			isDataTracker: false,
 			isCachedResult: false,
 			pageDisplayed: PAGE_DISPLAYED.main,
-			trending: '',
 		});
 
 		const trimmed = searchText.trim();

--- a/frontend/src/components/modules/hermes/hermesSearchHandler.js
+++ b/frontend/src/components/modules/hermes/hermesSearchHandler.js
@@ -91,7 +91,6 @@ const HermesSearchHandler = {
 			isCachedResult: false,
 			pageDisplayed: PAGE_DISPLAYED.main,
 			didYouMean: '',
-			trending: '',
 		});
 
 		const trimmed = searchText.trim();

--- a/frontend/src/components/modules/policy/policySearchHandler.js
+++ b/frontend/src/components/modules/policy/policySearchHandler.js
@@ -114,7 +114,6 @@ const PolicySearchHandler = {
 			isCachedResult: false,
 			pageDisplayed: PAGE_DISPLAYED.main,
 			didYouMean: '',
-			trending: '',
 			infiniteScrollPage: 1,
 		});
 

--- a/frontend/src/components/modules/simple/simpleSearchHandler.js
+++ b/frontend/src/components/modules/simple/simpleSearchHandler.js
@@ -92,7 +92,6 @@ const SimpleSearchHandler = {
 			isCachedResult: false,
 			pageDisplayed: PAGE_DISPLAYED.main,
 			didYouMean: '',
-			trending: '',
 		});
 
 		const trimmed = searchText.trim();


### PR DESCRIPTION
## Description

Fixed bug where selecting something in the advanced search dropdown would remove the Trending Searches section from the home page

## !vibez

chill

## Related Issue/Ticket

<!--- Generally 1 ticket per PR, but if there are smaller tickets used please list them out. -->
<!--- Please link to the issue/ticket here: -->

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

From the home page, go to the advanced search options and select a source or type. Verify this does not remove the trending searches section on the home page. Verify that the search itself also still works.

Repeat this for other clones.

## Checklist:

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [X] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
