### PR TITLE
fix search from favorite card and unfavoriting on user dash

### DIFF
--- a/frontend/src/components/cards/GCFavoriteCard.js
+++ b/frontend/src/components/cards/GCFavoriteCard.js
@@ -284,7 +284,6 @@ const FavoriteCard = (props) => {
 			setPopoverOpen(false);
 			setPopoverIdx(-1);
 		}
-		setReload(!reload);
 	};
 
 	const handleDelete = () => {

--- a/frontend/src/components/modules/policy/policyMainViewHandler.js
+++ b/frontend/src/components/modules/policy/policyMainViewHandler.js
@@ -356,7 +356,7 @@ const formatString = (text) => {
 };
 
 const handlePageLoad = async (props) => {
-	const { state, dispatch, gameChangerUserAPI, gameChangerAPI, cancelToken } = props;
+	const { state, dispatch, gameChangerAPI, cancelToken } = props;
 	await defaultHandlePageLoad(props);
 	setState(dispatch, { loadingrecDocs: true });
 	setState(dispatch, { loadingLastOpened: true });
@@ -366,8 +366,7 @@ const handlePageLoad = async (props) => {
 	let pop_pubs_inactive = [];
 	let rec_docs = [];
 
-	const user = await gameChangerUserAPI.getUserData();
-	const { favorite_documents = [], export_history = [], pdf_opened = [] } = user.data;
+	const { favorite_documents = [], export_history = [], pdf_opened = [] } = state.userData;
 
 	try {
 		const { data } = await gameChangerAPI.getHomepageEditorData({
@@ -1173,7 +1172,7 @@ const PolicyMainViewHandler = (props) => {
 	}, [state, dispatch, searchHandler]);
 
 	useEffect(() => {
-		if (state.cloneDataSet && state.historySet && !pageLoaded) {
+		if (state.cloneDataSet && state.historySet && !pageLoaded && state.userDataSet) {
 			const searchFactory = new SearchHandlerFactory(state.cloneData.search_module);
 			const tmpSearchHandler = searchFactory.createHandler();
 

--- a/frontend/src/components/user/GCUserDashboard.js
+++ b/frontend/src/components/user/GCUserDashboard.js
@@ -698,8 +698,6 @@ const GCUserDashboard = React.memo((props) => {
 		}
 	}, [userData, cloneData.clone_name, cloneData.url]);
 
-	useEffect(() => {}, [reload]);
-
 	const handleTabClicked = (tabIndex, lastIndex, event) => {
 		const tabName = event.target.title;
 		trackEvent(getTrackingNameForFactory(cloneData.clone_name), 'UserDashboardTab', 'onClick', tabName);

--- a/frontend/src/containers/GameChangerPage.js
+++ b/frontend/src/containers/GameChangerPage.js
@@ -51,16 +51,16 @@ const GameChangerPage = (props) => {
 			setState(dispatch, { history: history, historySet: true });
 		}
 
-		if (!state.userDataSet) {
-			gameChangerUserAPI.getUserProfileData().then((data) => {
-				setState(dispatch, { userData: data.data, userDataSet: true });
-			});
-		}
-
 		if (state.cloneDataSet && state.cloneData?.display_name) {
 			document.title = `ADVANA | ${cloneData.display_name.toUpperCase()}`;
 		}
 	}, [cloneData, state, dispatch, history]);
+
+	useEffect(() => {
+		if (!state.userDataSet) {
+			gameChangerUserAPI.getUserData();
+		}
+	}, [state.userDataSet]);
 
 	return (
 		<div className="main-container">


### PR DESCRIPTION
## Description

Fixes bug where search ing from a favorite search card would just stop on the front page and not search. Also fixes ability to unfavorite on user dash. 

## !vibez

Bugs abound

## Related Issue/Ticket

[UOT-144698](https://jira.di2e.net/browse/UOT-144698)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

* Navigate to the user dashboard. Go to favorite searches section (favorite one if you have't already). Click on a the title of a favorite search card to make the search. 
* On the user dash, click on the start of favorite cards to unfavorite. Go through the pop-up dialogue to make sure it works. (There are rerender issues that stop the star from being clicked for the first 10 or so seconds while page loads, but I think that is outside the scope of this issue)

## Checklist:

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
