### PR TITLE
refactor to get user dash group inputs to work again

### DIFF
--- a/frontend/src/components/common/GCCloseButton.js
+++ b/frontend/src/components/common/GCCloseButton.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import styled from 'styled-components';
+import CloseIcon from '@material-ui/icons/Close';
+
+const CloseButton = styled.div`
+	padding: 6px;
+	background-color: white;
+	border-radius: 5px;
+	color: #8091a5 !important;
+	border: 1px solid #b0b9be;
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	flex: 0.4;
+	position: absolute;
+	right: 15px;
+	top: 15px;
+`;
+
+export default function GCCloseButton({ onClick }) {
+	return (
+		<CloseButton onClick={() => onClick()}>
+			<CloseIcon fontSize="large" />
+		</CloseButton>
+	);
+}

--- a/frontend/src/components/user/AddToGroupModal.js
+++ b/frontend/src/components/user/AddToGroupModal.js
@@ -1,0 +1,187 @@
+import React, { useState } from 'react';
+import { Typography, FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel } from '@material-ui/core';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import GameChangerAPI from '../api/gameChanger-service-api';
+import GCTooltip from '../common/GCToolTip';
+import GCCloseButton from '../common/GCCloseButton';
+import GCButton from '../common/GCButton';
+import Modal from 'react-modal';
+import _ from 'lodash';
+
+const gameChangerAPI = new GameChangerAPI();
+
+const styles = {
+	menuItem: {
+		fontSize: 16,
+	},
+	modalError: {
+		color: '#f44336',
+	},
+};
+
+export default function AddToGroupModal(props) {
+	const {
+		showAddToGroupModal,
+		setShowAddToGroupModal,
+		documentGroups,
+		userData,
+		updateUserData,
+		favoriteDocuments,
+		classes,
+	} = props;
+
+	const [selectedGroup, setSelectedGroup] = useState({ id: null, name: '' });
+	const [addToGroupError, setAddToGroupError] = useState(false);
+	const [documentsToGroup, setDocumentsToGroup] = useState([]);
+
+	const handleChange = ({ target }) => {
+		setAddToGroupError('');
+		const groupId = documentGroups.find((group) => group.group_name === target.value).id;
+		setDocumentsToGroup([]);
+		setSelectedGroup({ id: groupId, name: target.value });
+	};
+
+	const handleCloseAddGroupModal = () => {
+		setAddToGroupError('');
+		setShowAddToGroupModal(false);
+		setDocumentsToGroup([]);
+	};
+
+	const handleAddToFavorites = async () => {
+		if (!selectedGroup.name) return setAddToGroupError('Please select a group');
+		const selectedGroupInfo = userData.favorite_groups.find((group) => group.id === selectedGroup.id);
+		let totalInGroup = documentsToGroup.length;
+		selectedGroupInfo.favorites.forEach((favId) => {
+			if (!documentsToGroup.includes(favId)) totalInGroup++;
+		});
+		if (totalInGroup > 5) return setAddToGroupError('Groups can only contain up to 5 items');
+		await gameChangerAPI.addTofavoriteGroupPOST({ groupId: selectedGroup.id, documentIds: documentsToGroup });
+		updateUserData();
+		handleCloseAddGroupModal();
+	};
+
+	const handleAddToGroupCheckbox = (value) => {
+		const newDocumentsToGroup = [...documentsToGroup];
+		const index = newDocumentsToGroup.indexOf(value);
+		if (index > -1) {
+			newDocumentsToGroup.splice(index, 1);
+		} else {
+			newDocumentsToGroup.push(value);
+		}
+		setDocumentsToGroup(newDocumentsToGroup);
+	};
+	const renderDocumentsToAdd = () => {
+		let groupFavorites;
+		if (selectedGroup.name)
+			groupFavorites = userData.favorite_groups.find(
+				(group) => group.group_name === selectedGroup.name
+			)?.favorites;
+		return (
+			<div style={{ overflow: 'auto', maxHeight: 300, display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)' }}>
+				{_.map(favoriteDocuments, (doc) => {
+					if (selectedGroup.name) {
+						if (groupFavorites?.includes(doc.favorite_id)) {
+							return <></>;
+						}
+					}
+					return (
+						<GCTooltip title={doc.title} placement="top" style={{ zIndex: 1001 }}>
+							<FormControlLabel
+								style={{ margin: '0px 0px 20px 0px' }}
+								control={
+									<Checkbox
+										onChange={() => handleAddToGroupCheckbox(doc.favorite_id)}
+										color="primary"
+										icon={
+											<CheckBoxOutlineBlankIcon
+												style={{ width: 25, height: 25, fill: 'rgb(224, 224, 224)' }}
+												fontSize="large"
+											/>
+										}
+										checkedIcon={
+											<CheckBoxIcon style={{ width: 25, height: 25, fill: '#386F94' }} />
+										}
+										key={doc.id}
+									/>
+								}
+								label={
+									<Typography variant="h6" noWrap className={classes.label}>
+										{doc.title}
+									</Typography>
+								}
+							/>
+						</GCTooltip>
+					);
+				})}
+			</div>
+		);
+	};
+	return (
+		<Modal
+			isOpen={showAddToGroupModal}
+			onRequestClose={() => handleCloseAddGroupModal()}
+			className={classes.addToGroupModal}
+			overlayClassName="new-group-modal-overlay"
+			id="new-group-modal"
+			closeTimeoutMS={300}
+			style={{ margin: 'auto', marginTop: '30px', display: 'flex', flexDirection: 'column' }}
+		>
+			<div>
+				<GCCloseButton onClick={() => handleCloseAddGroupModal()} />
+				<Typography variant="h2" style={{ width: '100%', fontSize: '24px', marginBottom: 20 }}>
+					Add Favorite Document to Group
+				</Typography>
+				<div style={{ width: 815 }}>
+					{selectedGroup.name && renderDocumentsToAdd()}
+					<FormControl variant="outlined" style={{ width: '100%' }}>
+						<InputLabel className={classes.labelFont}>Select Group</InputLabel>
+						<Select
+							classes={{ root: classes.groupSelect }}
+							value={selectedGroup.name}
+							onChange={handleChange}
+						>
+							{_.map(documentGroups, (group) => {
+								return (
+									<MenuItem style={styles.menuItem} value={group.group_name} key={group.id}>
+										{group.group_name}
+									</MenuItem>
+								);
+							})}
+						</Select>
+					</FormControl>
+					<div style={{ display: 'flex' }}>
+						{addToGroupError && <div style={styles.modalError}>{addToGroupError}</div>}
+						<div style={{ marginLeft: 'auto' }}>
+							<GCButton
+								onClick={() => handleCloseAddGroupModal()}
+								style={{
+									height: 40,
+									minWidth: 40,
+									padding: '2px 8px 0px',
+									fontSize: 14,
+									margin: '16px 0px 0px 10px',
+								}}
+								isSecondaryBtn
+							>
+								Close
+							</GCButton>
+							<GCButton
+								onClick={() => handleAddToFavorites()}
+								style={{
+									height: 40,
+									minWidth: 40,
+									padding: '2px 8px 0px',
+									fontSize: 14,
+									margin: '16px 0px 0px 10px',
+								}}
+							>
+								Save
+							</GCButton>
+						</div>
+					</div>
+				</div>
+			</div>
+		</Modal>
+	);
+}

--- a/frontend/src/components/user/GCUserDashboard.js
+++ b/frontend/src/components/user/GCUserDashboard.js
@@ -6,7 +6,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import GameChangerAPI from '../api/gameChanger-service-api';
 import { trackEvent } from '../telemetry/Matomo';
 import { Tabs, Tab, TabPanel, TabList } from 'react-tabs';
-import { Typography, FormControl, InputLabel, Select, MenuItem, Checkbox, FormControlLabel } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import GCTooltip from '../common/GCToolTip';
 import { backgroundGreyDark, backgroundWhite } from '../common/gc-colors';
 import { gcOrange } from '../common/gc-colors';
@@ -15,30 +15,21 @@ import LoadingIndicator from '@dod-advana/advana-platform-ui/dist/loading/Loadin
 import makeStyles from '@material-ui/core/styles/makeStyles';
 import Icon from '@material-ui/core/Icon';
 import GCButton from '../common/GCButton';
-import ExportResultsDialog, { downloadFile } from '../export/ExportResultsDialog';
+import { downloadFile } from '../export/ExportResultsDialog';
 import Popover from '@material-ui/core/Popover';
 import Popper from '@material-ui/core/Popper';
 import Link from '@material-ui/core/Link';
 import Badge from '@material-ui/core/Badge';
-import { decodeTinyUrl, getTrackingNameForFactory, getOrgToOrgQuery, getTypeQuery } from '../../utils/gamechangerUtils';
+import { decodeTinyUrl, getTrackingNameForFactory } from '../../utils/gamechangerUtils';
 import FavoriteCard from '../cards/GCFavoriteCard';
 import ReactTable from 'react-table';
 import TextField from '@material-ui/core/TextField';
 import Config from '../../config/config.js';
-import Modal from 'react-modal';
 import GCAccordion from '../common/GCAccordion';
-import {
-	handleGenerateGroup,
-	getSearchObjectFromString,
-	setCurrentTime,
-	getUserData,
-	setState,
-	clearDashboardNotification,
-} from '../../utils/sharedFunctions';
-import GCGroupCard from '../../components/cards/GCGroupCard';
-import CheckBoxIcon from '@material-ui/icons/CheckBox';
-import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import { clearDashboardNotification } from '../../utils/sharedFunctions';
 import moment from 'moment';
+import GroupsPanel from './GroupsPanel';
+import AddToGroupModal from './AddToGroupModal';
 
 const _ = require('lodash');
 
@@ -309,10 +300,6 @@ const useStyles = makeStyles((theme) => ({
 		backgroundColor: 'white',
 		padding: '0px 10px',
 	},
-	groupSelect: {
-		fontSize: '16px',
-		'&:focus': { backgroundColor: 'white' },
-	},
 }));
 
 const RESULTS_PER_PAGE = 12;
@@ -383,9 +370,6 @@ const GCUserDashboard = React.memo((props) => {
 	});
 	const [searchHistoryIdx, setSearchHistoryIdx] = useState(-1);
 
-	const [groupName, setGroupName] = useState('');
-	const [groupDescription, setGroupDescription] = useState('');
-
 	const [searchHistorySettingsPopperAnchorEl, setSearchHistorySettingsPopperAnchorEl] = useState(null);
 	const [searchHistorySettingsPopperOpen, setSearchHistorySettingsPopperOpen] = useState(false);
 	const [searchHistorySettingsData, setSearchHistorySettingsData] = useState({
@@ -396,14 +380,7 @@ const GCUserDashboard = React.memo((props) => {
 	});
 
 	const [documentGroups, setDocumentGroups] = useState([]);
-	const [showNewGroupModal, setShowNewGroupModal] = useState(false);
 	const [showAddToGroupModal, setShowAddToGroupModal] = useState(false);
-	const [selectedGroup, setSelectedGroup] = useState({});
-	const [documentsToGroup, setDocumentsToGroup] = useState([]);
-	const [showDeleteGroupModal, setShowDeleteGroupModal] = useState(false);
-	const [groupsToDelete, setGroupsToDelete] = useState([]);
-	const [addToGroupError, setAddToGroupError] = useState('');
-	const [createGroupError, setCreateGroupError] = useState('');
 
 	const [apiKeyPopperAnchorEl, setAPIKeyPopperAnchorEl] = useState(null);
 	const [apiKeyPopperOpen, setAPIKeyPopperOpen] = useState(false);
@@ -413,13 +390,6 @@ const GCUserDashboard = React.memo((props) => {
 	const classes = useStyles();
 
 	const preventDefault = (event) => event.preventDefault();
-
-	const handleChange = ({ target }) => {
-		setAddToGroupError('');
-		const groupId = documentGroups.find((group) => group.group_name === target.value).id;
-		setDocumentsToGroup([]);
-		setSelectedGroup({ id: groupId, name: target.value });
-	};
 
 	const searchHistoryColumns = [
 		{
@@ -685,7 +655,6 @@ const GCUserDashboard = React.memo((props) => {
 
 		if (userData.favorite_groups) {
 			setDocumentGroups(userData.favorite_groups);
-			setSelectedGroup({ id: null, name: '' });
 		}
 
 		if (userData.favorite_organizations) {
@@ -697,8 +666,6 @@ const GCUserDashboard = React.memo((props) => {
 			setFavoriteOrganizationsLoading(false);
 		}
 	}, [userData, cloneData.clone_name, cloneData.url]);
-
-	useEffect(() => {}, [reload]);
 
 	const handleTabClicked = (tabIndex, lastIndex, event) => {
 		const tabName = event.target.title;
@@ -923,93 +890,6 @@ const GCUserDashboard = React.memo((props) => {
 		updateUserData();
 	};
 
-	const handleAddToGroupCheckbox = (value) => {
-		const newDocumentsToGroup = [...documentsToGroup];
-		const index = newDocumentsToGroup.indexOf(value);
-		if (index > -1) {
-			newDocumentsToGroup.splice(index, 1);
-		} else {
-			newDocumentsToGroup.push(value);
-		}
-		setDocumentsToGroup(newDocumentsToGroup);
-	};
-
-	const handleDeleteGroupCheckbox = (value) => {
-		const newGroupsToDelete = [...groupsToDelete];
-		const index = newGroupsToDelete.indexOf(value);
-		if (index > -1) {
-			newGroupsToDelete.splice(index, 1);
-		} else {
-			newGroupsToDelete.push(value);
-		}
-		setGroupsToDelete(newGroupsToDelete);
-	};
-
-	const handleAddToFavorites = async () => {
-		if (!selectedGroup.name) return setAddToGroupError('Please select a group');
-		const selectedGroupInfo = userData.favorite_groups.find((group) => group.id === selectedGroup.id);
-		let totalInGroup = documentsToGroup.length;
-		selectedGroupInfo.favorites.forEach((favId) => {
-			if (!documentsToGroup.includes(favId)) totalInGroup++;
-		});
-		if (totalInGroup > 5) return setAddToGroupError('Groups can only contain up to 5 items');
-		await gameChangerAPI.addTofavoriteGroupPOST({ groupId: selectedGroup.id, documentIds: documentsToGroup });
-		updateUserData();
-		handleCloseAddGroupModal();
-	};
-
-	const handleCloseAddGroupModal = () => {
-		setAddToGroupError('');
-		setShowAddToGroupModal(false);
-		setDocumentsToGroup([]);
-	};
-
-	const renderDocumentsToAdd = () => {
-		let groupFavorites;
-		if (selectedGroup.name)
-			groupFavorites = userData.favorite_groups.find(
-				(group) => group.group_name === selectedGroup.name
-			)?.favorites;
-		return (
-			<div style={{ overflow: 'scroll', maxHeight: 300, display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)' }}>
-				{_.map(favoriteDocuments, (doc) => {
-					if (selectedGroup.name) {
-						if (groupFavorites?.includes(doc.favorite_id)) {
-							return <></>;
-						}
-					}
-					return (
-						<GCTooltip title={doc.title} placement="top" style={{ zIndex: 1001 }}>
-							<FormControlLabel
-								control={
-									<Checkbox
-										onChange={() => handleAddToGroupCheckbox(doc.favorite_id)}
-										color="primary"
-										icon={
-											<CheckBoxOutlineBlankIcon
-												style={{ width: 25, height: 25, fill: 'rgb(224, 224, 224)' }}
-												fontSize="large"
-											/>
-										}
-										checkedIcon={
-											<CheckBoxIcon style={{ width: 25, height: 25, fill: '#386F94' }} />
-										}
-										key={doc.id}
-									/>
-								}
-								label={
-									<Typography variant="h6" noWrap className={classes.label}>
-										{doc.title}
-									</Typography>
-								}
-							/>
-						</GCTooltip>
-					);
-				})}
-			</div>
-		);
-	};
-
 	const renderDocumentFavorites = () => {
 		return (
 			<div style={{ width: '100%', height: '100%' }}>
@@ -1038,77 +918,15 @@ const GCUserDashboard = React.memo((props) => {
 								</GCButton>
 							)}
 						</div>
-						<Modal
-							isOpen={showAddToGroupModal}
-							onRequestClose={() => handleCloseAddGroupModal()}
-							className={classes.addToGroupModal}
-							overlayClassName="new-group-modal-overlay"
-							id="new-group-modal"
-							closeTimeoutMS={300}
-							style={{ margin: 'auto', marginTop: '30px', display: 'flex', flexDirection: 'column' }}
-						>
-							<div>
-								<CloseButton onClick={() => handleCloseAddGroupModal()}>
-									<CloseIcon fontSize="large" />
-								</CloseButton>
-								<Typography variant="h2" style={{ width: '100%', fontSize: '24px' }}>
-									Add Favorite Document to Group
-								</Typography>
-								<div style={{ width: 815 }}>
-									{selectedGroup.name && renderDocumentsToAdd()}
-									<FormControl variant="outlined" style={{ width: '100%' }}>
-										<InputLabel className={classes.labelFont}>Select Group</InputLabel>
-										<Select
-											classes={{ root: classes.groupSelect }}
-											value={selectedGroup.name}
-											onChange={handleChange}
-										>
-											{_.map(documentGroups, (group) => {
-												return (
-													<MenuItem
-														style={styles.menuItem}
-														value={group.group_name}
-														key={group.id}
-													>
-														{group.group_name}
-													</MenuItem>
-												);
-											})}
-										</Select>
-									</FormControl>
-									<div style={{ display: 'flex' }}>
-										{addToGroupError && <div style={styles.modalError}>{addToGroupError}</div>}
-										<div style={{ marginLeft: 'auto' }}>
-											<GCButton
-												onClick={() => handleCloseAddGroupModal()}
-												style={{
-													height: 40,
-													minWidth: 40,
-													padding: '2px 8px 0px',
-													fontSize: 14,
-													margin: '16px 0px 0px 10px',
-												}}
-												isSecondaryBtn
-											>
-												Close
-											</GCButton>
-											<GCButton
-												onClick={() => handleAddToFavorites()}
-												style={{
-													height: 40,
-													minWidth: 40,
-													padding: '2px 8px 0px',
-													fontSize: 14,
-													margin: '16px 0px 0px 10px',
-												}}
-											>
-												Save
-											</GCButton>
-										</div>
-									</div>
-								</div>
-							</div>
-						</Modal>
+						<AddToGroupModal
+							showAddToGroupModal={showAddToGroupModal}
+							setShowAddToGroupModal={setShowAddToGroupModal}
+							documentGroups={documentGroups}
+							userData={userData}
+							updateUserData={updateUserData}
+							favoriteDocuments={favoriteDocuments}
+							classes={classes}
+						/>
 						<div style={{ height: '100%', overflow: 'hidden', marginBottom: 10 }}>
 							<div className={'col-xs-12'} style={{ padding: 0 }}>
 								<div className="row" style={{ marginLeft: 0, marginRight: 0 }}>
@@ -1904,291 +1722,8 @@ const GCUserDashboard = React.memo((props) => {
 		return (
 			<div>
 				<GCAccordion expanded={true} header={'DOCUMENT GROUPS'} itemCount={documentGroups.length}>
-					{renderDocumentGroups()}
+					<GroupsPanel state={state} dispatch={dispatch} documentGroups={documentGroups} />
 				</GCAccordion>
-			</div>
-		);
-	};
-
-	const handleSaveGroup = (groupType) => {
-		const group = {
-			group_type: groupType,
-			group_name: groupName,
-			group_description: groupDescription,
-			create: true,
-		};
-		if (documentGroups.filter((group) => group.group_name === groupName).length > 0) {
-			return setCreateGroupError('A group with that name already exists');
-		}
-		handleGenerateGroup(group, state, dispatch);
-		handleCloseNewGroupModal();
-	};
-
-	const handleDeleteGroup = () => {
-		const group = {
-			group_ids: groupsToDelete,
-			create: false,
-		};
-		handleGenerateGroup(group, state, dispatch);
-		handleCloseDeleteGroupModal();
-	};
-
-	const handleCloseDeleteGroupModal = () => {
-		setShowDeleteGroupModal(false);
-		setGroupsToDelete([]);
-	};
-
-	const handleCloseNewGroupModal = () => {
-		setShowNewGroupModal(false);
-		setGroupName('');
-		setGroupDescription('');
-		setCreateGroupError('');
-	};
-
-	const renderDocumentGroups = () => {
-		return (
-			<div style={{ width: '100%', height: '100%' }}>
-				<div style={{ height: '100%', overflow: 'hidden', marginBottom: 10 }}>
-					<div className={'col-xs-12'} style={{ padding: 0 }}>
-						<div
-							className="row"
-							style={{
-								display: 'flex',
-								justifyContent: 'flex-end',
-								paddingRight: 0,
-								marginLeft: 40,
-								width: '95%',
-							}}
-						>
-							<GCButton onClick={() => setShowDeleteGroupModal(true)} style={{}} isSecondaryBtn={true}>
-								Delete a Group
-							</GCButton>
-							<GCButton onClick={() => setShowNewGroupModal(true)} style={{}}>
-								Create a New Group
-							</GCButton>
-							<Modal
-								isOpen={showNewGroupModal}
-								onRequestClose={() => handleCloseNewGroupModal()}
-								className={classes.newGroupModal}
-								overlayClassName="new-group-modal-overlay"
-								id="new-group-modal"
-								closeTimeoutMS={300}
-								style={{ margin: 'auto', marginTop: '30px', display: 'flex', flexDirection: 'column' }}
-							>
-								<div>
-									<CloseButton onClick={() => handleCloseNewGroupModal()}>
-										<CloseIcon fontSize="large" />
-									</CloseButton>
-									<Typography variant="h2" style={{ width: '100%', fontSize: '24px' }}>
-										Create a New Group
-									</Typography>
-									<div style={{ width: 490 }}>
-										<TextField
-											label={'Name of the Group'}
-											value={groupName}
-											onChange={(event) => {
-												setGroupName(event.target.value);
-												setCreateGroupError('');
-											}}
-											error={createGroupError}
-											helperText={createGroupError}
-											className={classes.modalTextField}
-											margin="none"
-											size="small"
-											variant="outlined"
-										/>
-										<TextField
-											label={'Description'}
-											value={groupDescription}
-											onChange={(event) => {
-												setGroupDescription(event.target.value);
-											}}
-											className={classes.modalTextArea}
-											margin="none"
-											size="small"
-											variant="outlined"
-											multiline={true}
-											rows={4}
-										/>
-										<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-											<GCButton
-												onClick={() => handleCloseNewGroupModal()}
-												style={{
-													height: 40,
-													minWidth: 40,
-													padding: '2px 8px 0px',
-													fontSize: 14,
-													margin: '16px 0px 0px 10px',
-												}}
-												isSecondaryBtn
-											>
-												Close
-											</GCButton>
-											<GCButton
-												onClick={() => handleSaveGroup('document')}
-												style={{
-													height: 40,
-													minWidth: 40,
-													padding: '2px 8px 0px',
-													fontSize: 14,
-													margin: '16px 0px 0px 10px',
-												}}
-											>
-												Generate
-											</GCButton>
-										</div>
-									</div>
-								</div>
-							</Modal>
-							<Modal
-								isOpen={showDeleteGroupModal}
-								onRequestClose={() => handleCloseDeleteGroupModal()}
-								className={classes.newGroupModal}
-								overlayClassName="new-group-modal-overlay"
-								id="new-group-modal"
-								closeTimeoutMS={300}
-								style={{ margin: 'auto', marginTop: '30px', display: 'flex', flexDirection: 'column' }}
-							>
-								<div>
-									<CloseButton onClick={() => handleCloseDeleteGroupModal()}>
-										<CloseIcon fontSize="large" />
-									</CloseButton>
-									<Typography variant="h2" style={{ width: '100%', fontSize: '24px' }}>
-										Delete Groups
-									</Typography>
-									<div style={{ width: 490 }}>
-										{_.map(documentGroups, (group) => {
-											return (
-												<FormControlLabel
-													control={
-														<Checkbox
-															onChange={() => handleDeleteGroupCheckbox(group.id)}
-															color="primary"
-															icon={
-																<CheckBoxOutlineBlankIcon
-																	style={{
-																		width: 25,
-																		height: 25,
-																		fill: 'rgb(224, 224, 224)',
-																	}}
-																	fontSize="large"
-																/>
-															}
-															checkedIcon={
-																<CheckBoxIcon
-																	style={{ width: 25, height: 25, fill: '#386F94' }}
-																/>
-															}
-															key={group.id}
-														/>
-													}
-													label={
-														<Typography variant="h6" noWrap className={classes.label}>
-															{group.group_name}
-														</Typography>
-													}
-												/>
-											);
-										})}
-										<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
-											<GCButton
-												onClick={() => handleCloseDeleteGroupModal()}
-												style={{
-													height: 40,
-													minWidth: 40,
-													padding: '2px 8px 0px',
-													fontSize: 14,
-													margin: '16px 0px 0px 10px',
-												}}
-												isSecondaryBtn
-											>
-												Cancel
-											</GCButton>
-											<GCButton
-												onClick={() => handleDeleteGroup()}
-												style={{
-													height: 40,
-													minWidth: 40,
-													padding: '2px 8px 0px',
-													fontSize: 14,
-													margin: '16px 0px 0px 10px',
-												}}
-											>
-												Delete
-											</GCButton>
-										</div>
-									</div>
-								</div>
-							</Modal>
-							<ExportResultsDialog
-								open={state.exportDialogVisible}
-								handleClose={() =>
-									setState(dispatch, {
-										exportDialogVisible: false,
-										selectedDocuments: new Map(),
-										prevSearchText: '',
-									})
-								}
-								searchObject={getSearchObjectFromString(
-									state.prevSearchText ? state.prevSearchText : ''
-								)}
-								setCurrentTime={setCurrentTime}
-								selectedDocuments={state.selectedDocuments}
-								isSelectedDocs={true}
-								orgFilterString={getOrgToOrgQuery(
-									state.searchSettings.allOrgsSelected,
-									state.searchSettings.orgFilter
-								)}
-								typeFilterString={getTypeQuery(
-									state.searchSettings.allTypesSelected,
-									state.searchSettings.typeFilter
-								)}
-								orgFilter={state.searchSettings.orgFilter}
-								typeFilter={state.searchSettings.typeFilter}
-								getUserData={() => getUserData(dispatch)}
-								isClone={true}
-								cloneData={state.cloneData}
-								searchType={state.searchSettings.searchType}
-								edaSearchSettings={state.edaSearchSettings}
-								sort={state.currentSort}
-								order={state.currentOrder}
-							/>
-						</div>
-						{documentGroups.length > 0 ? (
-							<div className="row" style={{ marginLeft: 0, marginRight: 0 }}>
-								{_.map(documentGroups, (group, idx) => {
-									return (
-										<GCGroupCard
-											group={group}
-											state={state}
-											idx={idx}
-											dispatch={dispatch}
-											favorites={group.favorites}
-											key={group.id}
-										/>
-									);
-								})}
-							</div>
-						) : (
-							<StyledPlaceHolder>Make a group to see it listed here</StyledPlaceHolder>
-						)}
-					</div>
-				</div>
-
-				{/* {favoriteDocumentsSlice.length > 0 &&
-					<div className='gcPagination'>
-						<Pagination
-							activePage={documentFavoritesPage}
-							itemsCountPerPage={RESULTS_PER_PAGE}
-							totalItemsCount={documentFavoritesTotalCount}
-							pageRangeDisplayed={8}
-							onChange={page => {
-								trackEvent(getTrackingNameForFactory(cloneData.clone_name), 'UserDashboardDocumentFavorites', 'pagination', page);
-								handlePaginationChange(page, 'documentsFavorites');
-							}}
-						/>
-					</div>
-				} */}
 			</div>
 		);
 	};

--- a/frontend/src/components/user/GroupsPanel.js
+++ b/frontend/src/components/user/GroupsPanel.js
@@ -1,0 +1,438 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Modal from 'react-modal';
+import _ from 'lodash';
+import makeStyles from '@material-ui/core/styles/makeStyles';
+import CheckBoxIcon from '@material-ui/icons/CheckBox';
+import { Typography, Checkbox, FormControlLabel } from '@material-ui/core';
+import { TextField } from '@material-ui/core';
+import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
+import { getOrgToOrgQuery, getTypeQuery } from '../../utils/gamechangerUtils';
+import ExportResultsDialog from '../export/ExportResultsDialog';
+import GCGroupCard from '../../components/cards/GCGroupCard';
+import GCButton from '../common/GCButton';
+import {
+	handleGenerateGroup,
+	getSearchObjectFromString,
+	setCurrentTime,
+	getUserData,
+	setState,
+} from '../../utils/sharedFunctions';
+import GCCloseButton from '../common/GCCloseButton';
+
+const StyledPlaceHolder = styled.div`
+	font-family: Montserrat;
+	font-size: 20px;
+	font-weight: 300;
+	text-align: center;
+`;
+
+const useStyles = makeStyles((theme) => ({
+	root: {
+		padding: 0,
+
+		'&:hover': {
+			backgroundColor: 'transparent',
+		},
+	},
+	paper: {
+		border: '1px solid',
+		padding: theme.spacing(1),
+		backgroundColor: theme.palette.background.paper,
+	},
+	modalTextField: {
+		marginTop: '14px',
+		paddingBottom: '8px',
+		height: 'auto',
+		width: '100%',
+		'& .MuiFormHelperText-root': {
+			fontSize: 14,
+			marginLeft: 'unset',
+		},
+		'& .MuiInputBase-root': {
+			'& .MuiInputBase-input': {
+				height: '24px',
+				fontSize: '14px',
+			},
+		},
+		'& .MuiOutlinedInput-root': {
+			'&.Mui-disabled fieldset': {
+				borderColor: (props) => (props.error ? 'red' : 'inherit'),
+			},
+		},
+	},
+	modalTextArea: {
+		marginTop: '14px',
+		paddingBottom: '8px',
+		height: 'auto',
+		width: '100%',
+		'& .MuiFormHelperText-root': {
+			fontSize: 14,
+			marginLeft: 'unset',
+		},
+		'& .MuiInputBase-root': {
+			'& .MuiInputBase-input': {
+				fontSize: '14px',
+			},
+		},
+		'& .MuiOutlinedInput-root': {
+			'&.Mui-disabled fieldset': {
+				borderColor: (props) => (props.error ? 'red' : 'inherit'),
+			},
+		},
+	},
+	icon: {
+		borderRadius: 4,
+		color: '#DFE6EE',
+		width: 20,
+		height: 20,
+		boxShadow: 'inset 0 0 0 1px rgba(16,22,26,.2), inset 0 -1px 0 rgba(16,22,26,.1)',
+		backgroundColor: '#ffffff',
+		backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.8),hsla(0,0%,100%,0))',
+		'$root.Mui-focusVisible &': {
+			outline: '2px auto #DFE6EE',
+			outlineOffset: 2,
+		},
+		'input:hover ~ &': {
+			backgroundColor: '#ebf1f5',
+		},
+		'input:disabled ~ &': {
+			boxShadow: 'none',
+			background: 'rgba(206,217,224,.5)',
+		},
+	},
+	checkedIcon: {
+		backgroundColor: '#ffffff',
+		color: '#E9691D',
+		backgroundImage: 'linear-gradient(180deg,hsla(0,0%,100%,.1),hsla(0,0%,100%,0))',
+		'&:before': {
+			display: 'block',
+			width: 20,
+			height: 20,
+			backgroundImage:
+				`url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath` +
+				` fill-rule='evenodd' clip-rule='evenodd' d='M12 5c-.28 0-.53.11-.71.29L7 9.59l-2.29-2.3a1.003 ` +
+				`1.003 0 00-1.42 1.42l3 3c.18.18.43.29.71.29s.53-.11.71-.29l5-5A1.003 1.003 0 0012 5z' fill='%23E9691D'/%3E%3C/svg%3E")`,
+			content: '""',
+		},
+		'input:hover ~ &': {
+			backgroundColor: '#ebf1f5',
+		},
+	},
+	newGroupModal: {
+		position: 'fixed',
+		top: '35%',
+		left: '50%',
+		transform: 'translate(-50%, -50%)',
+		backgroundColor: 'white',
+		zIndex: 9999,
+		border: '1px solid #CCD8E5',
+		boxShadow: '0px 12px 14px #00000080',
+		borderRadius: '6px',
+		padding: 15,
+	},
+	addToGroupModal: {
+		position: 'fixed',
+		top: '35%',
+		left: '50%',
+		transform: 'translate(-50%, -50%)',
+		backgroundColor: 'white',
+		zIndex: 1000,
+		border: '1px solid #CCD8E5',
+		boxShadow: '0px 12px 14px #00000080',
+		borderRadius: '6px',
+		padding: 15,
+	},
+	label: {
+		fontSize: 14,
+		maxWidth: 350,
+	},
+	groupSelect: {
+		fontSize: '16px',
+		'&:focus': { backgroundColor: 'white' },
+	},
+}));
+
+export default function GroupsPanel(props) {
+	const { state, dispatch, documentGroups } = props;
+
+	const [showNewGroupModal, setShowNewGroupModal] = useState(false);
+	const [groupName, setGroupName] = useState('');
+	const [groupDescription, setGroupDescription] = useState('');
+	const [showDeleteGroupModal, setShowDeleteGroupModal] = useState(false);
+	const [groupsToDelete, setGroupsToDelete] = useState([]);
+	const [createGroupError, setCreateGroupError] = useState('');
+
+	const classes = useStyles();
+
+	const handleSaveGroup = (groupType) => {
+		const group = {
+			group_type: groupType,
+			group_name: groupName,
+			group_description: groupDescription,
+			create: true,
+		};
+		if (documentGroups.filter((group) => group.group_name === groupName).length > 0) {
+			return setCreateGroupError('A group with that name already exists');
+		}
+		handleGenerateGroup(group, state, dispatch);
+		handleCloseNewGroupModal();
+	};
+
+	const handleDeleteGroup = () => {
+		const group = {
+			group_ids: groupsToDelete,
+			create: false,
+		};
+		handleGenerateGroup(group, state, dispatch);
+		handleCloseDeleteGroupModal();
+	};
+
+	const handleCloseDeleteGroupModal = () => {
+		setShowDeleteGroupModal(false);
+		setGroupsToDelete([]);
+	};
+
+	const handleCloseNewGroupModal = () => {
+		setShowNewGroupModal(false);
+		setGroupName('');
+		setGroupDescription('');
+		setCreateGroupError('');
+	};
+
+	const handleDeleteGroupCheckbox = (value) => {
+		const newGroupsToDelete = [...groupsToDelete];
+		const index = newGroupsToDelete.indexOf(value);
+		if (index > -1) {
+			newGroupsToDelete.splice(index, 1);
+		} else {
+			newGroupsToDelete.push(value);
+		}
+		setGroupsToDelete(newGroupsToDelete);
+	};
+
+	return (
+		<div style={{ width: '100%', height: '100%' }}>
+			<div style={{ height: '100%', overflow: 'hidden', marginBottom: 10 }}>
+				<div className={'col-xs-12'} style={{ padding: 0 }}>
+					<div
+						className="row"
+						style={{
+							display: 'flex',
+							justifyContent: 'flex-end',
+							paddingRight: 0,
+							marginLeft: 40,
+							width: '95%',
+						}}
+					>
+						<GCButton onClick={() => setShowDeleteGroupModal(true)} style={{}} isSecondaryBtn={true}>
+							Delete a Group
+						</GCButton>
+						<GCButton onClick={() => setShowNewGroupModal(true)} style={{}}>
+							Create a New Group
+						</GCButton>
+						<Modal
+							isOpen={showNewGroupModal}
+							onRequestClose={() => handleCloseNewGroupModal()}
+							className={classes.newGroupModal}
+							overlayClassName="new-group-modal-overlay"
+							id="new-group-modal"
+							closeTimeoutMS={300}
+							style={{ margin: 'auto', marginTop: '30px', display: 'flex', flexDirection: 'column' }}
+						>
+							<div>
+								<GCCloseButton onClick={() => handleCloseNewGroupModal()} />
+								<Typography variant="h2" style={{ width: '100%', fontSize: '24px' }}>
+									Create a New Group
+								</Typography>
+								<div style={{ width: 490 }}>
+									<TextField
+										label={'Name of the Group'}
+										value={groupName}
+										onChange={(event) => {
+											setGroupName(event.target.value);
+											setCreateGroupError('');
+										}}
+										error={createGroupError}
+										helperText={createGroupError}
+										className={classes.modalTextField}
+										margin="none"
+										size="small"
+										variant="outlined"
+									/>
+									<TextField
+										label={'Description'}
+										value={groupDescription}
+										onChange={(event) => {
+											setGroupDescription(event.target.value);
+										}}
+										className={classes.modalTextArea}
+										margin="none"
+										size="small"
+										variant="outlined"
+										multiline={true}
+										rows={4}
+									/>
+									<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+										<GCButton
+											onClick={() => handleCloseNewGroupModal()}
+											style={{
+												height: 40,
+												minWidth: 40,
+												padding: '2px 8px 0px',
+												fontSize: 14,
+												margin: '16px 0px 0px 10px',
+											}}
+											isSecondaryBtn
+										>
+											Close
+										</GCButton>
+										<GCButton
+											onClick={() => handleSaveGroup('document')}
+											style={{
+												height: 40,
+												minWidth: 40,
+												padding: '2px 8px 0px',
+												fontSize: 14,
+												margin: '16px 0px 0px 10px',
+											}}
+										>
+											Generate
+										</GCButton>
+									</div>
+								</div>
+							</div>
+						</Modal>
+						<Modal
+							isOpen={showDeleteGroupModal}
+							onRequestClose={() => handleCloseDeleteGroupModal()}
+							className={classes.newGroupModal}
+							overlayClassName="new-group-modal-overlay"
+							id="new-group-modal"
+							closeTimeoutMS={300}
+							style={{ margin: 'auto', marginTop: '30px', display: 'flex', flexDirection: 'column' }}
+						>
+							<div>
+								<GCCloseButton onClick={() => handleCloseDeleteGroupModal()} />
+								<Typography variant="h2" style={{ width: '100%', fontSize: '24px' }}>
+									Delete Groups
+								</Typography>
+								<div style={{ width: 490 }}>
+									{_.map(documentGroups, (group) => {
+										return (
+											<FormControlLabel
+												control={
+													<Checkbox
+														onChange={() => handleDeleteGroupCheckbox(group.id)}
+														color="primary"
+														icon={
+															<CheckBoxOutlineBlankIcon
+																style={{
+																	width: 25,
+																	height: 25,
+																	fill: 'rgb(224, 224, 224)',
+																}}
+																fontSize="large"
+															/>
+														}
+														checkedIcon={
+															<CheckBoxIcon
+																style={{ width: 25, height: 25, fill: '#386F94' }}
+															/>
+														}
+														key={group.id}
+													/>
+												}
+												label={
+													<Typography variant="h6" noWrap className={classes.label}>
+														{group.group_name}
+													</Typography>
+												}
+											/>
+										);
+									})}
+									<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+										<GCButton
+											onClick={() => handleCloseDeleteGroupModal()}
+											style={{
+												height: 40,
+												minWidth: 40,
+												padding: '2px 8px 0px',
+												fontSize: 14,
+												margin: '16px 0px 0px 10px',
+											}}
+											isSecondaryBtn
+										>
+											Cancel
+										</GCButton>
+										<GCButton
+											onClick={() => handleDeleteGroup()}
+											style={{
+												height: 40,
+												minWidth: 40,
+												padding: '2px 8px 0px',
+												fontSize: 14,
+												margin: '16px 0px 0px 10px',
+											}}
+										>
+											Delete
+										</GCButton>
+									</div>
+								</div>
+							</div>
+						</Modal>
+						<ExportResultsDialog
+							open={state.exportDialogVisible}
+							handleClose={() =>
+								setState(dispatch, {
+									exportDialogVisible: false,
+									selectedDocuments: new Map(),
+									prevSearchText: '',
+								})
+							}
+							searchObject={getSearchObjectFromString(state.prevSearchText ? state.prevSearchText : '')}
+							setCurrentTime={setCurrentTime}
+							selectedDocuments={state.selectedDocuments}
+							isSelectedDocs={true}
+							orgFilterString={getOrgToOrgQuery(
+								state.searchSettings.allOrgsSelected,
+								state.searchSettings.orgFilter
+							)}
+							typeFilterString={getTypeQuery(
+								state.searchSettings.allTypesSelected,
+								state.searchSettings.typeFilter
+							)}
+							orgFilter={state.searchSettings.orgFilter}
+							typeFilter={state.searchSettings.typeFilter}
+							getUserData={() => getUserData(dispatch)}
+							isClone={true}
+							cloneData={state.cloneData}
+							searchType={state.searchSettings.searchType}
+							edaSearchSettings={state.edaSearchSettings}
+							sort={state.currentSort}
+							order={state.currentOrder}
+						/>
+					</div>
+					{documentGroups.length > 0 ? (
+						<div className="row" style={{ marginLeft: 0, marginRight: 0 }}>
+							{_.map(documentGroups, (group, idx) => {
+								return (
+									<GCGroupCard
+										group={group}
+										state={state}
+										idx={idx}
+										dispatch={dispatch}
+										favorites={group.favorites}
+										key={group.id}
+									/>
+								);
+							})}
+						</div>
+					) : (
+						<StyledPlaceHolder>Make a group to see it listed here</StyledPlaceHolder>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Description

Fixes bug where any change to an input in modals for adding to group favorites or creating a group would refresh the modal.

## !vibez

Bugs going down

## Related Issue/Ticket

[UOT-144702](https://jira.di2e.net/browse/UOT-144702)

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

(There are rerender issues for the first 10 or so seconds while page loads on the user dash, but I think that is outside the scope of this issue. Will create a separate  ticket)
* Navigate to the user dashboard. Go to the group tab. Click on create a group and create one making sure the inputs work as expected. 
* Navigate to the favorites tab and then to the documents section. Click the add to group button and ensure inputs work as expected. 
* Navigate back to the groups tab and delete a group and ensure inputs work as expected.

## Checklist:

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
