### PR TITLE
[UOT-145550] Updates to Organization Details page to incorporate `Org Head` and `Org Type(s)` information in table

### DIFF
--- a/backend/node_app/modules/policy/policyGraphHandler.js
+++ b/backend/node_app/modules/policy/policyGraphHandler.js
@@ -212,6 +212,10 @@ class PolicyGraphHandler extends GraphHandler {
 				return await this.getEntityDataDetailsPageHelper(req, userId);
 			case 'getTopicDataDetailsPage':
 				return await this.getTopicDataDetailsPageHelper(req, userId);
+			case 'getHeadDataDetailsPage':
+				return await this.getHeadDataDetailsPageHelper(req, userId)
+			case 'getTypeDataDetailsPage':
+				return await this.getTypeDataDetailsPageHelper(req, userId)
 			case 'getTopicDataPolicyGraph':
 				return await this.getTopicDataPolicyGraphHelper(req, userId);
 			case 'getReferencesPolicyGraph':
@@ -453,6 +457,54 @@ class PolicyGraphHandler extends GraphHandler {
 		} catch (err) {
 			const { message } = err;
 			this.logger.error(message, 'XAXUO60', userId);
+			return message;
+		}
+	}
+
+	async getHeadDataDetailsPageHelper(req, userId) {
+		try {
+			const { headName, isTest = false } = req.body;
+
+			const data = {};
+
+			const [headData] = await this.getGraphData(
+				'MATCH (e:Entity) WHERE e.name = $name ' +
+					'WITH e MATCH (e)-[:HAS_HEAD]->(h:Entity) ' +
+					'RETURN h.name as head;',
+				{ name: headName },
+				isTest,
+				userId
+			);
+
+			data.headData = headData;
+
+			return data;
+		} catch (err) {
+			const { message } = err;
+			this.logger.error(message, 'XADLO60', userId);
+			return message;
+		}
+	}
+
+	async getTypeDataDetailsPageHelper(req, userId) {
+		try {
+			const { typeName, isTest = false } = req.body;
+			const data = {};
+			const [typeData] = await this.getGraphData(
+				'MATCH (e:Entity) WHERE e.name = $name ' +
+					'WITH e MATCH (e)-[:TYPE_OF]->(t:Entity) ' +
+					'RETURN t as type;',
+				{ name: typeName },
+				isTest,
+				userId
+			);
+
+			data.typeData = typeData;
+
+			return data;
+		} catch (err) {
+			const { message } = err;
+			this.logger.error(message, 'BALLO93', userId);
 			return message;
 		}
 	}

--- a/backend/node_app/modules/policy/policyGraphHandler.js
+++ b/backend/node_app/modules/policy/policyGraphHandler.js
@@ -213,9 +213,9 @@ class PolicyGraphHandler extends GraphHandler {
 			case 'getTopicDataDetailsPage':
 				return await this.getTopicDataDetailsPageHelper(req, userId);
 			case 'getHeadDataDetailsPage':
-				return await this.getHeadDataDetailsPageHelper(req, userId)
+				return await this.getHeadDataDetailsPageHelper(req, userId);
 			case 'getTypeDataDetailsPage':
-				return await this.getTypeDataDetailsPageHelper(req, userId)
+				return await this.getTypeDataDetailsPageHelper(req, userId);
 			case 'getTopicDataPolicyGraph':
 				return await this.getTopicDataPolicyGraphHelper(req, userId);
 			case 'getReferencesPolicyGraph':

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -295,7 +295,7 @@ const GameChangerDetailsPage = (props) => {
 		if (resp.data.typeData.nodes && resp.data.typeData.nodes.length > 0) {
 			for (var i = 0; i < resp.data.typeData.nodes.length; i++) {
 				types += resp.data.typeData.nodes[i].name;
-				if (i != resp.data.typeData.nodes.length - 1) {
+				if (i !== resp.data.typeData.nodes.length - 1) {
 					types += ', ';
 				}
 			}

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -222,12 +222,18 @@ const GameChangerDetailsPage = (props) => {
 					}
 				}
 			});
-
+			tmpEntity.details.push({
+				name: 'Org Head',
+				value: await getHeadData(name, cloneName),
+			});
+			tmpEntity.details.push({
+				name: 'Org Type(s)',
+				value: await getTypeData(name, cloneName),
+			});
 			data.entity = tmpEntity;
 		}
 
 		data.graph = resp.data.graph;
-
 		return data;
 	};
 
@@ -260,6 +266,43 @@ const GameChangerDetailsPage = (props) => {
 		}
 
 		return data;
+	};
+
+	const getHeadData = async (name, cloneName) => {
+		const resp = await gameChangerAPI.callGraphFunction({
+			functionName: 'getHeadDataDetailsPage',
+			cloneName: cloneName,
+			options: {
+				headName: name,
+			},
+		});
+		if (resp.data.headData.head) {
+			return resp.data.headData.head;
+		} else {
+			return '';
+		}
+	};
+
+	const getTypeData = async (name, cloneName) => {
+		let types = '';
+		const resp = await gameChangerAPI.callGraphFunction({
+			functionName: 'getTypeDataDetailsPage',
+			cloneName: cloneName,
+			options: {
+				typeName: name,
+			},
+		});
+		if (resp.data.typeData.nodes && resp.data.typeData.nodes.length > 0) {
+			for (var i = 0; i < resp.data.typeData.nodes.length; i++) {
+				types += resp.data.typeData.nodes[i].name;
+				if (i != resp.data.typeData.nodes.length - 1) {
+					types += ', ';
+				}
+			}
+			return types;
+		} else {
+			return '';
+		}
 	};
 
 	const getSourceData = async (searchText, cloneName) => {

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -276,15 +276,11 @@ const GameChangerDetailsPage = (props) => {
 				headName: name,
 			},
 		});
-		if (resp.data.headData.head) {
-			return resp.data.headData.head;
-		} else {
-			return '';
-		}
+		const head = resp?.data?.headData?.head || '';
+		return head;
 	};
 
 	const getTypeData = async (name, cloneName) => {
-		let types = '';
 		const resp = await gameChangerAPI.callGraphFunction({
 			functionName: 'getTypeDataDetailsPage',
 			cloneName: cloneName,
@@ -292,17 +288,8 @@ const GameChangerDetailsPage = (props) => {
 				typeName: name,
 			},
 		});
-		if (resp.data.typeData.nodes && resp.data.typeData.nodes.length > 0) {
-			for (var i = 0; i < resp.data.typeData.nodes.length; i++) {
-				types += resp.data.typeData.nodes[i].name;
-				if (i !== resp.data.typeData.nodes.length - 1) {
-					types += ', ';
-				}
-			}
-			return types;
-		} else {
-			return '';
-		}
+		const types = resp?.data?.typeData?.nodes?.map((node) => node.name).join(', ') || '';
+		return types;
 	};
 
 	const getSourceData = async (searchText, cloneName) => {


### PR DESCRIPTION
**Description:**
This PR adds in additional attributes/relationships data into the Organization Details page based on additions to the graph (namely the Organization's Head and Organization Types information). This branch has been tested locally against both a local version of neo4j graph as well as the dev neo4j graph.

A screenshot of the updates (the table on the left hand side has been updated to add `Org Head` and `Org Type(s)`. 
![Screen Shot 2022-05-19 at 10 36 58 AM](https://user-images.githubusercontent.com/37678069/169323347-5e1c2d14-3533-49a7-b03c-6729c2619f5d.png)

