### PR TITLE
bugfix/UOT-146338 - Org Details Page

### DIFF
--- a/backend/node_app/modules/policy/policyGraphHandler.js
+++ b/backend/node_app/modules/policy/policyGraphHandler.js
@@ -459,16 +459,29 @@ class PolicyGraphHandler extends GraphHandler {
 
 	async getEntityDataDetailsPageHelper(req, userId) {
 		try {
-			const { entityName, isTest = false } = req.body;
+			let { entityName, isTest = false } = req.body;
 
 			const data = {};
 
-			const [entData, entQuery, entParams] = await this.getGraphData(
+			let [entData] = await this.getGraphData(
 				`MATCH (e:Entity) WHERE e.name = $name RETURN e;`,
 				{ name: entityName },
 				isTest,
 				userId
 			);
+
+			if (!entData?.nodes?.length > 0) {
+				// No match on name, attempt to match on alias
+				// This may have poor performance (needs investigation)
+				// This is a bandaid fix to cover up for data in neo4j not exactly matching elastic
+				[entData] = await this.getGraphData(
+					`MATCH (e:Entity) WHERE $name IN split(e.aliases, ';') RETURN e;`,
+					{ name: entityName },
+					isTest,
+					userId
+				);
+				entityName = entData?.nodes?.[0].name || entityName;
+			}
 
 			data.nodes = entData.nodes;
 


### PR DESCRIPTION
## Description
>Since the update to how orgs are ingested into the graph, some orgs won't open. The org names for neo4j come from a new source, so there may be a mismatch between the new neo4j name and the name we have in elastic. For instance, a search for "army" will return an org with the name "Army Corps of Engineers" from elastic, but it exists as "United States Army Corps of Engineers" in neo4j. Therefore the details page doesn't load.

This update will attempt to match on a node's aliases if no name match was found.

**Note:** This is a temporary fix for a greater issue ([ticket](https://jira.di2e.net/browse/UOT-146343))

## Related Issue/Ticket

https://jira.di2e.net/browse/UOT-146338

## Testing instructions

- Search for Army
- Go to organizations tab
- Details pages for Army Futures Command and Army Corps of Engineers should open and load data