### PR TITLE
adds sort by relevance as default

### DIFF
--- a/backend/node_app/modules/jbook/jbookSearchUtility.js
+++ b/backend/node_app/modules/jbook/jbookSearchUtility.js
@@ -1442,6 +1442,9 @@ class JBookSearchUtility {
 
 			// SORT
 			switch (jbookSearchSettings.sort[0].id) {
+				case 'relevance':
+					query.sort = [{ _score: { order: jbookSearchSettings.sort[0].desc ? 'desc' : 'asc' } }];
+					break;
 				case 'budgetYear':
 					query.sort = [{ budgetYear_s: { order: jbookSearchSettings.sort[0].desc ? 'desc' : 'asc' } }];
 					break;

--- a/frontend/src/components/modules/jbook/jbookContext.js
+++ b/frontend/src/components/modules/jbook/jbookContext.js
@@ -348,6 +348,7 @@ const initState = {
 	resetSettingsSwitch: false,
 	categorySorting: {
 		jbook: [
+			'Relevance',
 			'Budget Year',
 			'Program Element',
 			'Budget Line Item',
@@ -360,7 +361,7 @@ const initState = {
 			'Source',
 		],
 	},
-	currentSort: 'Budget Year',
+	currentSort: 'Relevance',
 	currentOrder: 'desc',
 	activeCategoryTab: 'jbook',
 

--- a/frontend/src/components/modules/jbook/jbookSearchHandler.js
+++ b/frontend/src/components/modules/jbook/jbookSearchHandler.js
@@ -354,6 +354,9 @@ const JBookSearchHandler = {
 		const sortDesc = state.currentOrder === 'desc';
 
 		switch (state.currentSort) {
+			case 'Relevance':
+				searchSettings.sort = [{ id: 'relevance', desc: sortDesc }];
+				break;
 			case 'Program Element':
 				searchSettings.sort = [{ id: 'programElement', desc: sortDesc }];
 				break;


### PR DESCRIPTION
- adds ES sort by relevance, sets it to default.
- to test, run a couple of searches using different searches + sorts. 'relevance' sorts by ES internal _score metric. 