### PR TITLE
Bugfix/pagehit no mapping

### DIFF
--- a/backend/node_app/modules/jbook/jbookDataMapping.js
+++ b/backend/node_app/modules/jbook/jbookDataMapping.js
@@ -1738,6 +1738,11 @@ module.exports = {
 		r4a_schedule_details_n: 'Schedule Details',
 		p3a_dev_milestones_n: 'Milestones',
 		budgetActivityTitle_s: 'Activity Title',
+		// unaccounted for (and ignored for now):
+		// r2a_other_program_funding_n
+		// p3a_rdte_n
+		// p5_cost_elements_n
+		// p5_res_sum_optional_rows_n
 	},
 
 	esInnerHitFields: [

--- a/backend/node_app/modules/jbook/jbookSearchUtility.js
+++ b/backend/node_app/modules/jbook/jbookSearchUtility.js
@@ -1053,10 +1053,12 @@ class JBookSearchUtility {
 					Object.keys(hit.inner_hits).forEach((hitKey) => {
 						hit.inner_hits[hitKey].hits.hits.forEach((innerHit) => {
 							Object.keys(innerHit.highlight).forEach((highlightKey) => {
-								result.pageHits.push({
-									title: esTopLevelFieldsNameMapping[hitKey],
-									snippet: innerHit.highlight[highlightKey][0],
-								});
+								if (esTopLevelFieldsNameMapping[hitKey] !== undefined) {
+									result.pageHits.push({
+										title: esTopLevelFieldsNameMapping[hitKey],
+										snippet: innerHit.highlight[highlightKey][0],
+									});
+								}
 							});
 						});
 					});


### PR DESCRIPTION
Card view was showing some tabs with no title, caused by no mapping match on the backend. 
- if there's no mapping, don't add those pagehits into the card. 
- saved the fields with no mapping commented for future reference, if needed. 