### PR TITLE
Uot 146956

### DIFF
--- a/frontend/src/components/modules/jbook/InputFilter.js
+++ b/frontend/src/components/modules/jbook/InputFilter.js
@@ -15,22 +15,21 @@ const InputFilter = (props) => {
 	const { state, dispatch } = context;
 
 	const [searchText, setSearchText] = useState(state.jbookSearchSettings[field]);
-	const [debouncedText, setDebouncedText] = useState('');
 
 	const handleChange = (event) => {
 		setSearchText(event.target.value);
 		debounce(event.target.value);
 	};
 
+	// eslint-disable-next-line react-hooks/exhaustive-deps
 	const debounce = useCallback(
 		_.debounce((_searchVal) => {
-			setDebouncedText(_searchVal);
 			// send the server request here
 			if (!state.initial) {
 				setJBookSetting(field, _searchVal.trim(), state, dispatch);
 				setState(dispatch, { runSearch: true, loading: true });
 			}
-		}, 500),
+		}, 1500),
 		[]
 	);
 	// useEffect(() => {

--- a/frontend/src/components/modules/jbook/jbookContext.js
+++ b/frontend/src/components/modules/jbook/jbookContext.js
@@ -386,6 +386,7 @@ const initState = {
 
 	// contract totals
 	contractTotals: {},
+	statsLoading: false,
 
 	paginationSearch: false,
 

--- a/frontend/src/components/modules/jbook/jbookSearchHandler.js
+++ b/frontend/src/components/modules/jbook/jbookSearchHandler.js
@@ -21,13 +21,13 @@ import GamechangerAPI from '../../api/gameChanger-service-api';
 const gamechangerAPI = new GamechangerAPI();
 let cancelToken = axios.CancelToken.source();
 
-const getAndSetDidYouMean = (index, searchText, dispatch) => {
-	// jbookAPI.getTextSuggestion({ index, searchText }).then(({ data }) => {
-	// 	setState(dispatch, {idYouMean: data?.autocorrect?.[0]});
-	// }).catch(_ => {
-	// 	//do nothing
-	// })
-};
+// const getAndSetDidYouMean = (index, searchText, dispatch) => {
+// 	jbookAPI.getTextSuggestion({ index, searchText }).then(({ data }) => {
+// 		setState(dispatch, {idYouMean: data?.autocorrect?.[0]});
+// 	}).catch(_ => {
+// 		//do nothing
+// 	})
+// };
 
 const JBookSearchHandler = {
 	updateRecentSearches(searchText) {
@@ -155,6 +155,7 @@ const JBookSearchHandler = {
 				urlSearch: false,
 				initial: false,
 				expansionDict: {},
+				statsLoading: true,
 			});
 
 			try {
@@ -166,7 +167,20 @@ const JBookSearchHandler = {
 				}
 
 				const results = await this.performQuery(state, searchText, resultsPage, dispatch, runningSearch);
-				const { contractTotals } = await this.getContractTotals(state, dispatch);
+				this.getContractTotals(state, dispatch)
+					.then(({ contractTotals }) => {
+						setState(dispatch, {
+							statsLoading: false,
+							contractTotals: contractTotals,
+						});
+					})
+					.catch(() => {
+						setState(dispatch, {
+							statsLoading: false,
+							contractTotals: {},
+						});
+					});
+
 				const t1 = new Date().getTime();
 
 				if (results === null || !results.docs || results.docs.length <= 0) {
@@ -203,7 +217,6 @@ const JBookSearchHandler = {
 						hideTabs: false,
 						resetSettingsSwitch: false,
 						runningSearch: false,
-						contractTotals: contractTotals,
 						expansionDict,
 						hasExpansionTerms,
 						paginationSearch: false,

--- a/frontend/src/components/modules/jbook/jbookSearchMatrixHandler.js
+++ b/frontend/src/components/modules/jbook/jbookSearchMatrixHandler.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import GCAccordion from '../../common/GCAccordion';
+import LoadingIndicator from '@dod-advana/advana-platform-ui/dist/loading/LoadingIndicator';
+import { GC_COLORS } from './jbookMainViewHandler';
 import SimpleTable from '../../common/SimpleTable';
 
 import _ from 'lodash';
@@ -431,7 +433,11 @@ const getSearchMatrixItems = (props) => {
 				headerTextColor={'white'}
 				headerTextWeight={'normal'}
 			>
-				{state.statsLoading && <div style={{ margin: '0 auto' }}>loading</div>}
+				{state.statsLoading && (
+					<div style={{ margin: '0 auto' }}>
+						<LoadingIndicator customColor={GC_COLORS.primary} />
+					</div>
+				)}
 				{!state.statsLoading && (
 					<div style={{ textAlign: 'left', width: '100%' }}>{renderStats(contractTotals)}</div>
 				)}


### PR DESCRIPTION
## Description

Fixes Primary Reviewer filters taking a long time to load results by letting search complete while waiting for budget results.
Also increases debounce for text input filters.

## !vibez

progress is progress

## Related Issue/Ticket

[OT-146956](https://jira.di2e.net/browse/UOT-146956)
[UOT-147113](https://jira.di2e.net/browse/UOT-147113)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (provides speedup with no functional changes)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Smoke testing instructions

* In Jbook search, expand Primary Reviewer filter and select 'Specific primary reviewers' the select 'Allen, Gregory'. Results should come back quickly, and a loading indicator should appear in the total budget section below filters while they load. 
* In 'Project #' or 'Program Element' filter, type something. New search should not fire immediately while typing but wait a second and a half.


## Checklist:

- [ ] Documentation updated
- [ ] Unit tests added/updated
- [ ] Smoke testing relevant to authentication needed
- [ ] Clones involved and accounted for
- [ ] RDS migrations or other data manipulation necessary
- [ ] Dev tools or other infrastructure changed
