### PR TITLE
Feature/general

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -184,22 +184,6 @@ const GamechangerLiteAdminPage = LoadableVisibility({
 	},
 });
 
-const GCFooter = LoadableVisibility({
-	loader: () => import('./components/navigation/GCFooter'),
-	loading: () => {
-		return (
-			<div
-				style={{
-					display: 'flex',
-					height: '90px',
-					width: '100%',
-					backgroundColor: 'black',
-				}}
-			/>
-		);
-	},
-});
-
 const instance = createInstance({
 	urlBase: Config.MATOMO_LINK || '',
 	siteId: Config.MATOMO_SITE_ID || 2,
@@ -304,13 +288,18 @@ const App = () => {
 						clone.available_at = []; // if there's nothing at all, set as empty array
 					}
 					if (clone.available_at.some((v) => v.includes(url) || v === 'all')) {
-						cloneRoutes.push(
+						cloneRoutes.push((location) => (
 							<PrivateTrackedRoute
 								key={`${clone.url}-admin-lite`}
 								path={`/${clone.url}/admin`}
 								render={(props) => (
 									<GamechangerProvider>
-										<GamechangerLiteAdminPage {...props} cloneData={clone} jupiter={false} />
+										<GamechangerLiteAdminPage
+											{...props}
+											cloneData={clone}
+											jupiter={false}
+											location={location}
+										/>
 									</GamechangerProvider>
 								)}
 								pageName={clone.display_name}
@@ -318,9 +307,9 @@ const App = () => {
 									return Permissions.permissionValidator(`${clone.clone_name} Admin`, true);
 								}}
 							/>
-						);
+						));
 						if (clone.permissions_required) {
-							cloneRoutes.push(
+							cloneRoutes.push((location) => (
 								<PrivateTrackedRoute
 									key={`${clone.url}-main`}
 									path={`/${clone.url}`}
@@ -336,6 +325,7 @@ const App = () => {
 												history={history}
 												isClone={true}
 												cloneData={clone}
+												location={location}
 											/>
 										</GamechangerProvider>
 									)}
@@ -347,13 +337,13 @@ const App = () => {
 										);
 									}}
 								/>
-							);
+							));
 						} else {
 							// if clone name is jbook, then push jbook route + cloneData
 							if (clone.clone_name === 'jbook') {
-								cloneRoutes.push(getJBookProfileRoute(clone));
+								cloneRoutes.push((location) => getJBookProfileRoute(clone, location));
 							}
-							cloneRoutes.push(
+							cloneRoutes.push((location) => (
 								<PrivateTrackedRoute
 									key={`${clone.url}-main`}
 									path={`/${clone.url}`}
@@ -369,6 +359,7 @@ const App = () => {
 												history={history}
 												isClone={true}
 												cloneData={clone}
+												location={location}
 											/>
 										</GamechangerProvider>
 									)}
@@ -377,7 +368,7 @@ const App = () => {
 										return true;
 									}}
 								/>
-							);
+							));
 						}
 					}
 				}
@@ -389,7 +380,7 @@ const App = () => {
 		}
 	};
 
-	const getJBookProfileRoute = (cloneData) => {
+	const getJBookProfileRoute = (cloneData, location) => {
 		const JBookProvider = getProvider('jbook');
 
 		return (
@@ -398,7 +389,7 @@ const App = () => {
 				path={`/jbook/profile`}
 				render={(props) => (
 					<JBookProvider>
-						<JBookProfilePage {...props} cloneData={cloneData} />
+						<JBookProfilePage {...props} cloneData={cloneData} location={location} />
 					</JBookProvider>
 				)}
 				pageName={'JBookProfilePage'}
@@ -467,10 +458,6 @@ const App = () => {
 		}
 	}
 
-	const setUserMatomo = (value) => {
-		localStorage.setItem('userMatomo', value);
-	};
-
 	return (
 		<Router>
 			<MatomoProvider value={instance}>
@@ -490,10 +477,7 @@ const App = () => {
 												<SlideOutMenu match={match} location={location} history={history} />
 											)}
 											<Switch>
-												{tokenLoaded &&
-													gameChangerCloneRoutes.map((route) => {
-														return route;
-													})}
+												{tokenLoaded && gameChangerCloneRoutes.map((route) => route(location))}
 												<Route
 													exact
 													path="/"
@@ -518,6 +502,7 @@ const App = () => {
 															true
 														);
 													}}
+													location={location}
 												/>
 												<PrivateTrackedRoute
 													key={`gamechanger-es`}
@@ -527,6 +512,7 @@ const App = () => {
 													allowFunction={() => {
 														return true;
 													}}
+													location={location}
 												/>
 												<TrackedPDFView
 													path="/pdfviewer/gamechanger"
@@ -544,7 +530,6 @@ const App = () => {
 										</ErrorBoundary>
 									</>
 								</SlideOutMenuContextHandler>
-								<GCFooter setUserMatomo={setUserMatomo} location={location} />
 							</div>
 						)}
 					/>

--- a/frontend/src/components/aboutUs/GCAboutUs.js
+++ b/frontend/src/components/aboutUs/GCAboutUs.js
@@ -5,7 +5,8 @@ import anchorme from 'anchorme';
 import sanitizeHtml from 'sanitize-html';
 import TabStyles from '../common/TabStyles';
 import { Typography } from '@material-ui/core';
-
+import { setState } from '../../utils/sharedFunctions';
+import { PAGE_DISPLAYED } from '../../utils/gamechangerUtils';
 import GCAccordion from '../common/GCAccordion';
 import GameChangerAPI from '../api/gameChanger-service-api';
 
@@ -58,7 +59,8 @@ const styles = {
 };
 
 const GCAboutUs = (props) => {
-	const [tabIndex, setTabIndex] = useState('about');
+	const { initialTab, state, dispatch } = props;
+	const [tabIndex, setTabIndex] = useState(initialTab === 'faq' ? 1 : 0);
 	const [selectedCategory, setSelectedCategory] = useState('general');
 	const [FAQdata, setFAQdata] = useState([]);
 	const categoryRefs = useRef([]);
@@ -120,6 +122,28 @@ const GCAboutUs = (props) => {
 		window.addEventListener('scroll', onScroll);
 		return () => window.removeEventListener('scroll', onScroll);
 	}, [selectedCategory, onScroll]);
+
+	// if initialTab changes, navigate to that tab
+	// (this can happen if a user is viewing the FAQ and clicks the sidebar aboutUs button)
+	useEffect(() => {
+		if (initialTab === 'faq') {
+			window.history.pushState(
+				null,
+				document.title,
+				`/#/${state.cloneData.url.toLowerCase()}/${PAGE_DISPLAYED.faq}`
+			);
+			setState(dispatch, { pageDisplayed: PAGE_DISPLAYED.faq });
+			setTabIndex(1);
+		} else {
+			window.history.pushState(
+				null,
+				document.title,
+				`/#/${state.cloneData.url.toLowerCase()}/${PAGE_DISPLAYED.aboutUs}`
+			);
+			setState(dispatch, { pageDisplayed: PAGE_DISPLAYED.aboutUs });
+			setTabIndex(0);
+		}
+	}, [initialTab, dispatch, state.cloneData.url]);
 
 	const renderAboutGC = () => {
 		return [
@@ -358,17 +382,36 @@ const GCAboutUs = (props) => {
 
 	return (
 		<div style={TabStyles.tabContainer}>
-			<Tabs>
+			<Tabs
+				selectedIndex={tabIndex}
+				onSelect={(index) => {
+					if (index === 1) {
+						window.history.pushState(
+							null,
+							document.title,
+							`/#/${state.cloneData.url.toLowerCase()}/${PAGE_DISPLAYED.faq}`
+						);
+						setState(dispatch, { pageDisplayed: PAGE_DISPLAYED.faq });
+					} else {
+						window.history.pushState(
+							null,
+							document.title,
+							`/#/${state.cloneData.url.toLowerCase()}/${PAGE_DISPLAYED.aboutUs}`
+						);
+						setState(dispatch, { pageDisplayed: PAGE_DISPLAYED.aboutUs });
+					}
+					setTabIndex(index);
+				}}
+			>
 				<div style={{ ...TabStyles.tabButtonContainer, paddingLeft: 0 }}>
 					<TabList style={TabStyles.tabsList}>
 						<Tab
 							style={{
 								...TabStyles.tabStyle,
-								...(tabIndex === 'about' ? TabStyles.tabSelectedStyle : {}),
+								...(tabIndex === 0 ? TabStyles.tabSelectedStyle : {}),
 								borderRadius: `5px 0 0 0`,
 							}}
 							title="userHistory"
-							onClick={() => setTabIndex('about')}
 						>
 							<Typography variant="h6" display="inline" title="cardView">
 								ABOUT GAMECHANGER
@@ -377,11 +420,10 @@ const GCAboutUs = (props) => {
 						<Tab
 							style={{
 								...TabStyles.tabStyle,
-								...(tabIndex === 'faq' ? TabStyles.tabSelectedStyle : {}),
+								...(tabIndex === 1 ? TabStyles.tabSelectedStyle : {}),
 								borderRadius: `5px 0 0 0`,
 							}}
 							title="userHistory"
-							onClick={() => setTabIndex('faq')}
 						>
 							<Typography variant="h6" display="inline" title="cardView">
 								FAQ

--- a/frontend/src/components/modules/policy/policyMainViewHandler.js
+++ b/frontend/src/components/modules/policy/policyMainViewHandler.js
@@ -1104,8 +1104,13 @@ const getCardViewPanel = (props) => {
 };
 
 const getAboutUs = (props) => {
-	const { state } = props;
-	return <GCAboutUs state={state} />;
+	const { state, dispatch } = props;
+	return <GCAboutUs state={state} dispatch={dispatch} initialTab="about" />;
+};
+
+const getFAQ = (props) => {
+	const { state, dispatch } = props;
+	return <GCAboutUs state={state} dispatch={dispatch} initialTab="faq" />;
 };
 
 const getAnalystTools = (context) => {
@@ -1211,7 +1216,9 @@ const PolicyMainViewHandler = (props) => {
 				dispatch
 			);
 		case PAGE_DISPLAYED.aboutUs:
-			return getNonMainPageOuterContainer(getAboutUs({ state }), state, dispatch);
+			return getNonMainPageOuterContainer(getAboutUs({ state, dispatch }), state, dispatch);
+		case PAGE_DISPLAYED.faq:
+			return getNonMainPageOuterContainer(getFAQ({ state, dispatch }), state, dispatch);
 		case PAGE_DISPLAYED.main:
 		default:
 			return getMainView({

--- a/frontend/src/components/navigation/GCFooter.js
+++ b/frontend/src/components/navigation/GCFooter.js
@@ -1,7 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import AdvanaFooter from '@dod-advana/advana-platform-ui/dist/AdvanaFooter';
 import { Button, Checkbox, FormControlLabel, FormGroup, Modal, TextField, Typography } from '@material-ui/core';
-// import JAICLogo from '../../images/logos/JAIC_wht.png';
+// import JAICLogo from '../../images/logos/JAIC_wht.png';\
+import { getContext } from '../factories/contextFactory';
 import styled from 'styled-components';
 import CheckBoxOutlineBlankIcon from '@material-ui/icons/CheckBoxOutlineBlank';
 import GameChangerAPI from '../api/gameChanger-service-api';
@@ -10,6 +11,8 @@ import { makeStyles } from '@material-ui/core/styles';
 import CloseIcon from '@material-ui/icons/Close';
 import GCButton from '../common/GCButton';
 import RequestAPIKeyDialog from '../api/RequestAPIKeyDialog';
+import { PAGE_DISPLAYED } from '../../utils/gamechangerUtils';
+import { setState, setUserMatomo } from '../../utils/sharedFunctions';
 
 const gameChangerAPI = new GameChangerAPI();
 const gcUserManagementAPI = new GamechangerUserManagementAPI();
@@ -91,10 +94,26 @@ const CloseButton = styled.div`
 	top: 15px;
 `;
 
+const FAQLinkButton = () => {
+	const context = useContext(getContext('gamechanger'));
+	const { dispatch } = context;
+	return (
+		<LinkButton
+			key="faq"
+			onClick={() => {
+				window.history.pushState(null, document.title, `/#/gamechanger/${PAGE_DISPLAYED.faq}`);
+				setState(dispatch, { pageDisplayed: PAGE_DISPLAYED.faq });
+			}}
+		>
+			FAQ
+		</LinkButton>
+	);
+};
+
 const GCFooter = (props) => {
 	const classes = useStyles();
 
-	const { setUserMatomo, location } = props;
+	const { location, cloneName } = props;
 
 	const [trackingModalOpen, setTrackingModalOpen] = useState(false);
 	const [apiRequestModalOpen, setApiRequestModalOpen] = useState(false);
@@ -281,11 +300,16 @@ const GCFooter = (props) => {
 	};
 
 	const getExtraLinks = () => {
-		const extraLinks = [
+		const extraLinks = [];
+		if (cloneName === 'gamechanger') {
+			extraLinks.push(<FAQLinkButton />);
+		}
+		extraLinks.push(
 			<LinkButton key="disclaimer" onClick={() => setTrackingModalOpen(true)}>
 				App-wide Tracking Agreement
-			</LinkButton>,
-		];
+			</LinkButton>
+		);
+
 		if (!location['pathname'].includes('search')) {
 			extraLinks.push(
 				<LinkButton key="apiKeyRequest" onClick={() => setApiRequestModalOpen(true)}>

--- a/frontend/src/components/navigation/GCFooter.js
+++ b/frontend/src/components/navigation/GCFooter.js
@@ -105,7 +105,7 @@ const FAQLinkButton = () => {
 				setState(dispatch, { pageDisplayed: PAGE_DISPLAYED.faq });
 			}}
 		>
-			FAQ
+			FAQs
 		</LinkButton>
 	);
 };

--- a/frontend/src/containers/GameChangerDetailsPage.js
+++ b/frontend/src/containers/GameChangerDetailsPage.js
@@ -31,6 +31,7 @@ import EditIcon from '@material-ui/icons/Edit';
 import EditEntityDialog from '../components/admin/EditEntityDialog';
 import GamechangerUserManagementAPI from '../components/api/GamechangerUserManagement';
 import dodSeal from '../images/United_States_Department_of_Defense_Seal.svg.png';
+import LoadableVisibility from 'react-loadable-visibility/react-loadable';
 
 const gameChangerAPI = new GameChangerAPI();
 const gcUserManagementAPI = new GamechangerUserManagementAPI();
@@ -134,6 +135,22 @@ const FavoriteTopic = styled.button`
 		color: ${({ favorited }) => (favorited ? '#E9691D' : '#B0B9BE')};
 	}
 `;
+
+const GCFooter = LoadableVisibility({
+	loader: () => import('../components/navigation/GCFooter'),
+	loading: () => {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					height: '90px',
+					width: '100%',
+					backgroundColor: 'black',
+				}}
+			/>
+		);
+	},
+});
 
 const GameChangerDetailsPage = (props) => {
 	const { location } = props;
@@ -916,41 +933,43 @@ const GameChangerDetailsPage = (props) => {
 	};
 
 	return (
-		<div style={{ minHeight: 'calc(100% - 89px)', background: 'white' }}>
+		<div style={{ minHeight: 'calc(100vh - 30px)', background: 'white', display: 'flex', flexDirection: 'column' }}>
 			<TitleBar
 				detailsType={detailsType}
 				titleBarModule={'details/detailsTitleBarHandler'}
 				rawSearchResults={[]}
 			></TitleBar>
+			<div style={{ flexGrow: 1 }}>
+				{showEntityContainer && renderEntityContainer()}
 
-			{showEntityContainer && renderEntityContainer()}
+				{showTopicContainer && renderTopicContainer()}
 
-			{showTopicContainer && renderTopicContainer()}
+				{showSourceContainer && !_.isEmpty(cloneData) && !_.isEmpty(initialSourceData) && (
+					<SourceDetailsPage
+						source={source}
+						cloneData={cloneData}
+						initialSourceData={initialSourceData}
+						userData={userData}
+						rawSearchResults={docResults}
+					/>
+				)}
 
-			{showSourceContainer && !_.isEmpty(cloneData) && !_.isEmpty(initialSourceData) && (
-				<SourceDetailsPage
-					source={source}
-					cloneData={cloneData}
-					initialSourceData={initialSourceData}
-					userData={userData}
-					rawSearchResults={docResults}
-				/>
-			)}
+				{showDocumentContainer && (
+					<DocumentDetailsPage
+						document={document}
+						cloneData={cloneData}
+						runningQuery={runningQuery}
+						graphData={graph}
+						userData={userData}
+						rawSearchResults={docResults}
+					/>
+				)}
 
-			{showDocumentContainer && (
-				<DocumentDetailsPage
-					document={document}
-					cloneData={cloneData}
-					runningQuery={runningQuery}
-					graphData={graph}
-					userData={userData}
-					rawSearchResults={docResults}
-				/>
-			)}
-
-			{showContractContainer && edaPermissions && (
-				<EDAContractDetailsPage awardID={contractAwardID} cloneData={cloneData} />
-			)}
+				{showContractContainer && edaPermissions && (
+					<EDAContractDetailsPage awardID={contractAwardID} cloneData={cloneData} />
+				)}
+			</div>
+			<GCFooter location={location} cloneName="gamechanger-details" />
 		</div>
 	);
 };

--- a/frontend/src/containers/GameChangerPage.js
+++ b/frontend/src/containers/GameChangerPage.js
@@ -22,6 +22,22 @@ const UserFeedback = LoadableVisibility({
 	},
 });
 
+const GCFooter = LoadableVisibility({
+	loader: () => import('../components/navigation/GCFooter'),
+	loading: () => {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					height: '90px',
+					width: '100%',
+					backgroundColor: 'black',
+				}}
+			/>
+		);
+	},
+});
+
 export const gcColors = {
 	buttonColor1: '#131E43',
 	buttonColor2: '#E9691D',
@@ -34,9 +50,10 @@ export const scrollToContentTop = () => {
 };
 
 const GameChangerPage = (props) => {
-	const { cloneData, history, jupiter, tutorialData } = props;
+	const { cloneData, history, jupiter, tutorialData, location } = props;
 
 	const cloneName = cloneData.clone_name;
+
 	const context = useContext(getContext(cloneName));
 	const { state, dispatch } = context;
 
@@ -91,7 +108,7 @@ const GameChangerPage = (props) => {
 					{state.cloneDataSet && <SearchBar context={context} jupiter={jupiter} />}
 
 					{/* Main View */}
-					{state.historySet && <MainView context={context} />}
+					<div style={{ flexGrow: 1 }}>{state.historySet && <MainView context={context} />}</div>
 
 					{/* Snack BAr Messages */}
 					<div>
@@ -110,6 +127,8 @@ const GameChangerPage = (props) => {
 						message={state.backendErrorMsg || ''}
 						onClose={() => setState(dispatch, { showBackendError: false })}
 					/>
+					{/* Footer */}
+					{<GCFooter location={location} cloneName={cloneName} />}
 				</>
 			)}
 		</div>

--- a/frontend/src/containers/GamechangerAdminPage.js
+++ b/frontend/src/containers/GamechangerAdminPage.js
@@ -81,6 +81,22 @@ const GeneralAdminButtons = LoadableVisibility({
 	},
 });
 
+const GCFooter = LoadableVisibility({
+	loader: () => import('../components/navigation/GCFooter'),
+	loading: () => {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					height: '90px',
+					width: '100%',
+					backgroundColor: 'black',
+				}}
+			/>
+		);
+	},
+});
+
 const PAGES = {
 	general: 'General',
 	cloneList: 'CloneList',
@@ -135,7 +151,7 @@ const userListTableAdditions = [
  * @class GamechangerAdminPage
  */
 const GamechangerAdminPage = (props) => {
-	const { jupiter } = props;
+	const { jupiter, location } = props;
 
 	const [pageToView, setPageToView] = useState(PAGES.general);
 	const { setToolState, unsetTool } = useContext(SlideOutToolContext);
@@ -190,10 +206,9 @@ const GamechangerAdminPage = (props) => {
 	}, [unsetTool, setToolState, setPageToView]);
 
 	return (
-		<div style={{ minHeight: 'calc(100vh - 120px)' }}>
+		<div style={{ minHeight: 'calc(100vh - 30px)', display: 'flex', flexDirection: 'column' }}>
 			<SlideOutMenuContent type="closed">{ClosedAdminMenu({ setPageToView, PAGES })}</SlideOutMenuContent>
 			<SlideOutMenuContent type="open">{OpenedAdminMenu({ setPageToView, PAGES })}</SlideOutMenuContent>
-
 			<TitleBar
 				onTitleClick={() => {
 					window.location.href = `#/gamechanger-admin`;
@@ -204,11 +219,13 @@ const GamechangerAdminPage = (props) => {
 				rawSearchResults={[]}
 				cloneData={{ clone_name: 'gamechanger' }}
 			/>
-
-			<Switch>
-				<Route exact path={`${path}/mldashboard`} component={MLDashboard} />
-				<Route path="*" component={() => renderSwitch(pageToView)} />
-			</Switch>
+			<div style={{ flexGrow: 1 }}>
+				<Switch>
+					<Route exact path={`${path}/mldashboard`} component={MLDashboard} />
+					<Route path="*" component={() => renderSwitch(pageToView)} />
+				</Switch>
+			</div>
+			<GCFooter location={location} cloneName="gamechanger-admin" />
 		</div>
 	);
 };

--- a/frontend/src/containers/GamechangerEsPage.js
+++ b/frontend/src/containers/GamechangerEsPage.js
@@ -5,6 +5,7 @@ import Select from '@material-ui/core/Select';
 import MenuItem from '@material-ui/core/MenuItem';
 import GameChangerAPI from '../components/api/gameChanger-service-api';
 import Permissions from '@dod-advana/advana-platform-ui/dist/utilities/permissions';
+import LoadableVisibility from 'react-loadable-visibility/react-loadable';
 
 const styles = {
 	splitScreen1: {
@@ -17,7 +18,23 @@ const styles = {
 	},
 };
 
-const GamechangerEsPage = (props) => {
+const GCFooter = LoadableVisibility({
+	loader: () => import('../components/navigation/GCFooter'),
+	loading: () => {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					height: '90px',
+					width: '100%',
+					backgroundColor: 'black',
+				}}
+			/>
+		);
+	},
+});
+
+const GamechangerEsPage = ({ location }) => {
 	const gameChangerApi = new GameChangerAPI();
 
 	const [query, setQuery] = useState('');
@@ -46,61 +63,64 @@ const GamechangerEsPage = (props) => {
 	};
 
 	return (
-		<div style={{ height: 800, width: '100%' }}>
-			<div style={styles.splitScreen1}>
-				<TextField
-					style={{ width: '100%' }}
-					label={'Query'}
-					multiline
-					rows={13}
-					maxRows={13}
-					value={query}
-					onChange={handleQueryChange}
-					disableUnderline={true}
-					inputProps={{ style: { fontSize: 12, fontFamily: 'Noto Sans' } }}
-				/>
-				{!loading ? (
-					<Button
-						variant="contained"
-						onClick={() => {
-							handleSubmit();
-						}}
-					>
-						Submit
-					</Button>
-				) : (
-					<p>Querying...</p>
-				)}
-				{Permissions.allowGCClone('eda') && !loading ? (
-					<Select
-						value={esClient}
-						style={{ marginLeft: 30 }}
-						inputProps={{ style: { fontSize: 10, fontFamily: 'Noto Sans' } }}
-						onChange={handleClientChange}
-					>
-						<MenuItem
-							value={'gamechanger'}
-							inputProps={{ style: { fontSize: 10, fontFamily: 'Noto Sans' } }}
+		<div style={{ minHeight: 'calc(100vh - 30px)', display: 'flex', flexDirection: 'column' }}>
+			<div style={{ minHeight: 800, width: '100%', flexGrow: 1 }}>
+				<div style={styles.splitScreen1}>
+					<TextField
+						style={{ width: '100%' }}
+						label={'Query'}
+						multiline
+						rows={13}
+						maxRows={13}
+						value={query}
+						onChange={handleQueryChange}
+						disableUnderline={true}
+						inputProps={{ style: { fontSize: 12, fontFamily: 'Noto Sans' } }}
+					/>
+					{!loading ? (
+						<Button
+							variant="contained"
+							onClick={() => {
+								handleSubmit();
+							}}
 						>
-							gamechanger
-						</MenuItem>
-						<MenuItem value={'eda'} inputProps={{ style: { fontSize: 10, fontFamily: 'Noto Sans' } }}>
-							eda
-						</MenuItem>
-					</Select>
-				) : (
-					''
-				)}
+							Submit
+						</Button>
+					) : (
+						<p>Querying...</p>
+					)}
+					{Permissions.allowGCClone('eda') && !loading ? (
+						<Select
+							value={esClient}
+							style={{ marginLeft: 30 }}
+							inputProps={{ style: { fontSize: 10, fontFamily: 'Noto Sans' } }}
+							onChange={handleClientChange}
+						>
+							<MenuItem
+								value={'gamechanger'}
+								inputProps={{ style: { fontSize: 10, fontFamily: 'Noto Sans' } }}
+							>
+								gamechanger
+							</MenuItem>
+							<MenuItem value={'eda'} inputProps={{ style: { fontSize: 10, fontFamily: 'Noto Sans' } }}>
+								eda
+							</MenuItem>
+						</Select>
+					) : (
+						''
+					)}
+				</div>
+				<div
+					style={{
+						...styles.splitScreen2,
+						fontFamily: 'Noto Sans',
+						fontSize: 12,
+					}}
+				>
+					<pre>{JSON.stringify(results, null, 2)}</pre>
+				</div>
 			</div>
-			<div
-				style={{
-					...styles.splitScreen2,
-					fontFamily: 'Noto Sans',
-					fontSize: 12,
-				}}
-			>
-				<pre>{JSON.stringify(results, null, 2)}</pre>
-			</div>
+			<GCFooter location={location} cloneName="gamechanger-es" />
 		</div>
 	);
 };

--- a/frontend/src/containers/JBookProfilePage.js
+++ b/frontend/src/containers/JBookProfilePage.js
@@ -10,6 +10,7 @@ import GCPrimaryButton from '../components/common/GCButton';
 import Permissions from '@dod-advana/advana-platform-ui/dist/utilities/permissions';
 import { gcOrange } from '../components/common/gc-colors';
 import CloseIcon from '@material-ui/icons/Close';
+import LoadableVisibility from 'react-loadable-visibility/react-loadable';
 import { getQueryVariable } from '../utils/gamechangerUtils';
 import './gamechanger.css';
 import './jbook.css';
@@ -45,8 +46,24 @@ const _ = require('lodash');
 
 const gameChangerAPI = new GameChangerAPI();
 
+const GCFooter = LoadableVisibility({
+	loader: () => import('../components/navigation/GCFooter'),
+	loading: () => {
+		return (
+			<div
+				style={{
+					display: 'flex',
+					height: '90px',
+					width: '100%',
+					backgroundColor: 'black',
+				}}
+			/>
+		);
+	},
+});
+
 const JBookProfilePage = (props) => {
-	const { cloneData } = props;
+	const { cloneData, location } = props;
 
 	const context = useContext(JBookContext);
 	const { state, dispatch } = context;
@@ -1068,6 +1085,8 @@ const JBookProfilePage = (props) => {
 				</StyledReviewLeftContainer>
 				<StyledReviewRightContainer></StyledReviewRightContainer>
 			</StyledReviewContainer>
+			{/* Footer */}
+			{<GCFooter location={location} cloneName="jbook" />}
 		</div>
 	);
 };

--- a/frontend/src/containers/gamechanger.css
+++ b/frontend/src/containers/gamechanger.css
@@ -101,7 +101,9 @@
 
 .main-container { 
     background-color: white;
-    min-height: calc(100vh - 120px);
+    min-height: calc(100vh - 30px);
+    display: flex;
+    flex-direction: column;
 }
 
 #gc-user-dash .row > * { 

--- a/frontend/src/utils/gamechangerUtils.js
+++ b/frontend/src/utils/gamechangerUtils.js
@@ -39,6 +39,7 @@ export const PAGE_DISPLAYED = {
 	dataTracker: 'dataTracker',
 	analystTools: 'analystTools',
 	aboutUs: 'aboutUs',
+	faq: 'faq',
 };
 
 export const SEARCH_TYPES = {

--- a/frontend/src/utils/sharedFunctions.js
+++ b/frontend/src/utils/sharedFunctions.js
@@ -261,7 +261,7 @@ export const getNonMainPageOuterContainer = (innerChildren, state, dispatch) => 
 					minHeight: 'calc(100vh - 200px)',
 				}}
 			>
-				{state.pageDisplayed !== 'aboutUs' && (
+				{state.pageDisplayed !== 'aboutUs' && state.pageDisplayed !== 'faq' && (
 					<div
 						style={{
 							borderTop: '1px solid #B0BAC5',
@@ -272,7 +272,7 @@ export const getNonMainPageOuterContainer = (innerChildren, state, dispatch) => 
 					/>
 				)}
 				<React.Fragment>
-					{state.pageDisplayed !== 'aboutUs' && (
+					{state.pageDisplayed !== 'aboutUs' && state.pageDisplayed !== 'faq' && (
 						<Button
 							style={{
 								marginLeft: '10px',
@@ -337,7 +337,8 @@ export const getNonMainPageOuterContainer = (innerChildren, state, dispatch) => 
 							backgroundColor:
 								state.pageDisplayed === PAGE_DISPLAYED.dataTracker ||
 								state.pageDisplayed === PAGE_DISPLAYED.analystTools ||
-								state.pageDisplayed === PAGE_DISPLAYED.aboutUs
+								state.pageDisplayed === PAGE_DISPLAYED.aboutUs ||
+								state.pageDisplayed === PAGE_DISPLAYED.faq
 									? '#ffffff'
 									: '#DFE6EE',
 						}}
@@ -348,4 +349,8 @@ export const getNonMainPageOuterContainer = (innerChildren, state, dispatch) => 
 			</div>
 		</div>
 	);
+};
+
+export const setUserMatomo = (value) => {
+	localStorage.setItem('userMatomo', value);
 };


### PR DESCRIPTION
## Description of this Feature

- Have faq page have its own url distinct from aboutUs page
- Add a link to the faq page in the app footer for gamechanger (no link for clones)
- Move the footer from being rendered by App.js to being rendered inside the context provider for each clone
- Adjust styling of footer/main container to still have it align to the bottom of the page

## Issues/Tickets Contained in this Feature

- #582 

## Smoke testing instructions

Generally verify that the separate urls for the About Us vs FAQ tabs work:

Go to /gamechanger/aboutUs
Verify the About Us page loads
Click the FAQ tab
Verify that the url changes to /gamechanger/faq and the page goes to the FAQ tab
Click the About Us tab
Verify that the url changes to /gamechanger/aboutUs and the page goes to the About Us tab
Go somewhere else in the app (like /gamechanger)
Click the About Us icon from the sidebar
Verify that the url changes to /gamechanger/aboutUs and the page goes back to the About Us tab
Go to /gamechanger/faq
Verify the page goes back to the FAQ tab
Verify that the footer is displayed appropriately

Verify the footer has a "FAQ" link in it when you are on the gamechanger clone
Verify that the footer is bottom aligned while on the gamechanger clone
Verify that the footer does not have the "FAQ" link when you are on any of the other clones (including jbook)
Verify that the footer is still bottom aligned while on other clones (including jbook)
Verify that the FAQ link in the footer works

From gamechanger clone, click the FAQ link in the footer
Verify that the url changes to /gamechanger/faq and the page goes to the FAQ tab
Go to about us tab
Repeat steps 1 & 2 and make sure it correctly switches tabs


## Link to Server with this Feature Branch

http://10.194.9.88:8080/

## Review Checklist:

- [ ] Features mentioned in this pull request work as intended
- [ ] UI appears to be unaffected by this PR
- [ ] No knew bugs were introduced in the PR
- [ ] Approved
