### PR TITLE
Bugfix/118 hotfix - add in import missing from jbookProfilePageHelper

### DIFF
--- a/frontend/src/components/modules/jbook/profilePage/jbookProfilePageHelper.js
+++ b/frontend/src/components/modules/jbook/profilePage/jbookProfilePageHelper.js
@@ -10,6 +10,7 @@ import {
 	StyledNavButton,
 	StyledNavBar,
 	StyledNavContainer,
+	StyledLeftContainer,
 	StyledSideNavContainer,
 } from './profilePageStyles';
 import ThumbUpOffAltIcon from '@mui/icons-material/ThumbUpOffAlt';


### PR DESCRIPTION
There is a missing import in jbookProfilePageHelper that causes the frontend to not compile. This should fix it!